### PR TITLE
Allowed service start/stop/restart on Amazon Linux

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -19,7 +19,7 @@
 
 action :start do
   case node.platform
-  when 'ubuntu','debian','centos','redhat','fedora'
+  when 'ubuntu','debian','centos','redhat','fedora', 'amazon'
     if ::File.exists?("/etc/init.d/redis#{new_resource.server_port}")
       execute "/etc/init.d/redis#{new_resource.server_port} start"
     else
@@ -30,7 +30,7 @@ end
 
 action :stop do
   case node.platform
-  when 'ubuntu','debian','centos','redhat','fedora'
+  when 'ubuntu','debian','centos','redhat','fedora', 'amazon'
     if ::File.exists?("/etc/init.d/redis#{new_resource.server_port}")
       execute "/etc/init.d/redis#{new_resource.server_port} stop"
     else
@@ -41,7 +41,7 @@ end
 
 action :restart do
   case node.platform
-  when 'ubuntu','debian','centos','redhat','fedora'
+  when 'ubuntu','debian','centos','redhat','fedora', 'amazon'
     if ::File.exists?("/etc/init.d/redis#{new_resource.server_port}")
       execute "/etc/init.d/redis#{new_resource.server_port} stop && /etc/init.d/redis#{new_resource.server_port} start"
     else


### PR DESCRIPTION
Hello,

first of all, thanks for really nice cookbook.

We figured out, that redis won't start on Amazon Linux, because of missing start/stop/restart definition of service. Is there some reason for that? If not, this commit should resolve this :).

Thanks
Vojtech
