### PR TITLE
Adds cookbook parameter to template resource within install provider

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -141,6 +141,7 @@ def configure
       #Lay down the configuration files for the current instance
       template "#{current['configdir']}/#{current['port']}.conf" do
         source 'redis.conf.erb'
+        cookbook 'redisio'
         owner current['user']
         group current['group']
         mode '0644'
@@ -178,6 +179,7 @@ def configure
       #Setup init.d file
       template "/etc/init.d/redis#{current['port']}" do
         source 'redis.init.erb'
+        cookbook 'redisio'
         owner 'root'
         group 'root'
         mode '0755'


### PR DESCRIPTION
To use the LWRP outside the cookbook it's necessary to specify the
cookbook where the template source resides (redisio).
