### PR TITLE
Ignore metadata.json, so that the cookbook can be submoduled into another repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *swp
 *swo
+metadata.json


### PR DESCRIPTION
We created a submodule in our cookbooks/ dir to track redisio directly. W/o this ignore, chef created metadata.json and the tree shows as dirty.
