### PR TITLE
Support non-standard bind address in service stop command

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -185,6 +185,7 @@ def configure
         mode '0755'
         variables({
           :port => current['port'],
+          :address => current['address'],
           :user => current['user'],
           :configdir => current['configdir'],
           :piddir => piddir,

--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -40,7 +40,7 @@ case "$1" in
         else
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
-                $CLIEXEC -p $REDISPORT<%= @requirepass ? " -a '#{@requirepass}'" : "" %> shutdown
+                $CLIEXEC <%= @address ? "-h #{@address}" : ""%> -p $REDISPORT<%= @requirepass ? " -a '#{@requirepass}'" : "" %> shutdown
                 while [ -x /proc/${PID} ]
                 do
                     echo "Waiting for Redis to shutdown ..."


### PR DESCRIPTION
When you specify a bind address, service stop failed to connect. This commit passes whatever you set into the init script.
