### PR TITLE
add unixsocket support

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -173,7 +173,9 @@ def configure
           :noappendfsynconrewrite => current['noappendfsynconrewrite'],
           :aofrewritepercentage   => current['aofrewritepercentage'] ,
           :aofrewriteminsize      => current['aofrewriteminsize'],
-          :includes               => current['includes']
+          :includes               => current['includes'],
+          :unixsocket             => current['unixsocket'],
+          :unixsocketperm         => current['unixsocketperm']
         })
       end
       #Setup init.d file

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -36,6 +36,9 @@ port <%=@port%>
 #
 # unixsocket /tmp/redis.sock
 # unixsocketperm 755
+<%= "unixsocket #{@unixsocket}" unless @unixsocket.nil? %>
+<%= "unixsocketperm #{@unixsocketperm}" unless @unixsocketperm.nil? %>
+
 # Close the connection after a client is idle for N seconds (0 to disable)
 <%= "timeout #{@timeout}" %>
 


### PR DESCRIPTION
We connect to redis via unixsocket for some projects. This adds that capability to the LWRP. Off by default.
