### PR TITLE
make the pid directory if needed

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -23,6 +23,11 @@ CLIEXEC=/usr/local/bin/redis-cli
 
 PIDFILE=<%= @piddir %>/redis_${REDISPORT}.pid
 
+if [ ! -d <%= @piddir %> ]; then
+    mkdir -p <%= @piddir %>
+    chown <%= @user %>  <%= @piddir %>
+fi
+
 case "$1" in
     start)
         if [ -f $PIDFILE ]


### PR DESCRIPTION
After a reboot, /var/run may be empty, so the pidfile cannot be created. redis will start, but the init script cannot stop it. This just makes the directory if needed. 

We may not need to do the create in chef also??
