### PR TITLE
allow user to be added as a system user

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -80,6 +80,7 @@ def configure
         supports :manage_home => true
         home current['homedir']
         shell current['shell']
+        system current['systemuser']
       end
       #Create the redis configuration directory
       directory current['configdir'] do


### PR DESCRIPTION
We generally run our daemons with uid's below 1000.  When adding a "normal" user in ubuntu via chef without specifying a uid, it often clashes with our real human users.  We let the OS select the uids for system users.  Could also just allow the user of the recipe to specify the uid.
