### PR TITLE
Add ulimit support to init.d script

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -222,7 +222,8 @@ def configure
           :requirepass => current['requirepass'],
           :shutdown_save => current['shutdown_save'],
           :platform => node['platform'],
-          :unixsocket => current['unixsocket']
+          :unixsocket => current['unixsocket'],
+          :ulimit => descriptors
           })
         only_if { current['job_control'] == 'initd' }
       end

--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -38,6 +38,8 @@ if [ ! -d <%= @piddir %> ]; then
     chown <%= @user %>  <%= @piddir %>
 fi
 
+ulimit -n <%= @ulimit %>
+
 case "$1" in
     start)
         if [ -f $PIDFILE ]


### PR DESCRIPTION
This is an oversight in the upstream version and cannot be fixed in a wrapper. Tested in Dev.
