### PR TITLE
Add configuration options for redis cluster

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -79,6 +79,9 @@ default['redisio']['default_settings'] = {
   'noappendfsynconrewrite' => 'no',
   'aofrewritepercentage'   => '100',
   'aofrewriteminsize'      => '64mb',
+  'cluster-enabled'        => 'no',
+  'cluster-config-file'    => nil, # Defaults to redis instance name inside of template if cluster is enabled.
+  'cluster-node-timeout'   => 5,
   'includes'               => nil
 }
 

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -201,6 +201,9 @@ def configure
           :noappendfsynconrewrite => current['noappendfsynconrewrite'],
           :aofrewritepercentage   => current['aofrewritepercentage'] ,
           :aofrewriteminsize      => current['aofrewriteminsize'],
+          :clusterenabled         => current['cluster-enabled'],
+          :clusterconfigfile      => current['cluster-config-file'],
+          :clusternodetimeout     => current['cluster-node-timeout'],
           :includes               => current['includes']
         })
       end

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -521,6 +521,12 @@ zset-max-ziplist-value 64
 # want to free memory asap when possible.
 activerehashing yes
 
+<%if @clusterenabled == 'yes' %>
+cluster-enabled yes
+cluster-config-file <%= @clusterconfigfile || "nodes-#{@name}.conf" %>
+cluster-node-timeout <%= @clusternodetimeout %>
+<%end%>
+
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you


### PR DESCRIPTION
I've added three configuration options for the new redis cluster:

```
clusterenabled
clusterconfigfile
clusternodetimeout
```

If `clusterenabled` isn't set to `yes`, none of the above options are included in the config file (for backwards compatibility).
