### PR TITLE
Make default port 6379 a default_setting attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,7 +82,8 @@ default['redisio']['default_settings'] = {
   'cluster-enabled'        => 'no',
   'cluster-config-file'    => nil, # Defaults to redis instance name inside of template if cluster is enabled.
   'cluster-node-timeout'   => 5,
-  'includes'               => nil
+  'includes'               => nil,
+  'port'                   => '6379'
 }
 
 # The default for this is set inside of the "install" recipe. This is due to the way deep merge handles arrays

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -24,7 +24,7 @@ location = "#{redis['mirror']}/#{redis['base_name']}#{redis['version']}.#{redis[
 
 redis_instances = redis['servers']
 if redis_instances.nil?
-  redis_instances = [{'port' => '6379'}]
+  redis_instances = [{'port' => redis['default_settings']['port']}]
 end
 
 redisio_install "redis-servers" do
@@ -61,7 +61,6 @@ redis_instances.each do |current_server|
   else
     Chef::Log.error("Unknown job control type, no service resource created!")
   end
-
 end
 
 node.set['redisio']['servers'] = redis_instances 


### PR DESCRIPTION
We want to construct a redis_url during compile phase but don't want to hard code the default port so makes sense to move 6379 from install recipe into the default_settings attributes and use that instead.
