### PR TITLE
Fix maxmemory as a percentage

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -80,7 +80,7 @@ def configure
       # Just assume this is sensible like "95%" or "95 %"
       percent_factor = current['maxmemory'].to_f / 100.0
       # Ohai reports memory in KB as it looks in /proc/meminfo
-      maxmemory = (node_memory_kb * 1024 * percent_factor / new_resource.servers.length).to_i
+      maxmemory = (node_memory_kb * 1024 * percent_factor / new_resource.servers.length).to_s
     end
 
     descriptors = current['ulimit'] == 0 ? current['maxclients'] + 32 : current['maxclients']


### PR DESCRIPTION
If specifying max memory as a percentage of system memory, force calculated value to a string to avoid causing problems with the `redis.conf.erb` template. Fixes #59.
