### PR TITLE
Custom installation directory

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,9 @@ default['redisio']['artifact_type'] = 'tar.gz'
 default['redisio']['version'] = '2.6.13'
 default['redisio']['base_piddir'] = '/var/run/redis'
 
+#Custom installation directory
+default['redisio']['install_dir'] = nil
+
 #Default settings for all redis instances, these can be overridden on a per server basis in the 'servers' hash
 default['redisio']['default_settings'] = {
   'user'                   => 'redis',

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -52,7 +52,9 @@ def build
 end
 
 def install
-  execute "cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make install"
+  install_prefix = ""
+  install_prefix = "PREFIX=#{new_resource.install_dir}" if new_resource.install_dir
+  execute "cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make #{install_prefix} install"
   new_resource.updated_by_last_action(true)
 end
 
@@ -208,6 +210,8 @@ def configure
         })
       end
       #Setup init.d file
+      cli_path = "/usr/local/bin"
+      cli_path = ::File.join(node['redisio']['install_dir'], 'bin') if node['redisio']['install_dir']
       template "/etc/init.d/redis#{server_name}" do
         source 'redis.init.erb'
         cookbook 'redisio'
@@ -216,6 +220,7 @@ def configure
         mode '0755'
         variables({
           :name => server_name,
+          :cli_path => cli_path,
           :job_control => current['job_control'],
           :port => current['port'],
           :address => current['address'],

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -34,6 +34,7 @@ redisio_install "redis-servers" do
   servers redis_instances
   safe_install redis['safe_install']
   base_piddir redis['base_piddir']
+  install_dir redis['install_dir']
 end
 
 # Create a service resource for each redis instance, named for the port it runs on.

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -30,6 +30,8 @@ attribute :base_name, :kind_of => String, :default => 'redis-'
 attribute :safe_install, :kind_of => [ TrueClass, FalseClass ], :default => true
 attribute :base_piddir, :kind_of => String, :default => '/var/run/redis'
 
+attribute :install_dir, :kind_of => String, :default => nil
+
 #Configuration attributes
 attribute :user, :kind_of => String, :default => 'redis'
 attribute :group, :kind_of => String, :default => 'redis'

--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -20,7 +20,7 @@ EXEC="sudo -u <%= @user %> /usr/local/bin/redis-server <%= @configdir %>/${REDIS
 <% else %> 
 EXEC="runuser <%= @user %> -c \"/usr/local/bin/redis-server <%= @configdir %>/${REDISNAME}.conf\""
 <% end %>
-CLIEXEC=/usr/local/bin/redis-cli
+CLIEXEC=<%= File.join(@cli_path, 'redis-cli') %>
 
 <% connection_string = String.new %>
 <% if @unixsocket.nil? %> 


### PR DESCRIPTION
Adds support to install Redis into a custom location, instead of only installing into /usr/local.
