### PR TITLE
[ADD] redis-sentinel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,43 @@ default_attributes({
 })
 ```
 
+#### Install redis, and setup one instance + one redis-sentinel
+
+For more information see: http://redis.io/topics/sentinel
+
+```ruby 
+run_list *%w[
+  recipe[redisio::install]
+  recipe[redisio::enable]
+]
+
+default_attributes({
+  'redisio' => {
+    'servers' => [
+      {'name' => "my_redis_server", 'port' => "6379"},
+      {'name' => "my_redis_sentinel", 'port' => "26379",
+        #you can set more than one redis to watch by adding another sentinel config to array
+        "sentinels" => [
+          {
+            'master_name' => "master_name",
+            'port' => "6379",
+            'ip' => "127.0.0.1",
+
+            #(optional) parameters - shown values are default
+            'level_of_agreement' => 1,          
+            'down_after_milliseconds' => 60000,
+            'failover_timeout' => 900000,
+            'can_failover' => 'yes',
+            'parallel_syncs' => 1
+          }
+        ]
+      }
+    ]
+  }
+})
+
+```
+
 LWRP Examples
 -------------
 

--- a/templates/default/redis-sentinel.conf.erb
+++ b/templates/default/redis-sentinel.conf.erb
@@ -1,0 +1,306 @@
+# REDIS SENTINEL CONFIGURATION
+
+<% @sentinels.each do |sentinel| %>
+sentinel monitor <%= sentinel[:master_name] %> <%= sentinel[:ip] %> <%= sentinel[:port] %> <%= sentinel[:level_of_agreement] %>
+sentinel down-after-milliseconds <%= sentinel[:master_name] %>  <%= sentinel[:down_after_milliseconds] || 60000 %> 
+sentinel failover-timeout <%= sentinel[:master_name] %>  <%= sentinel[:failover_timeout] || 900000 %> 
+sentinel can-failover <%= sentinel[:master_name] %> <%= sentinel[:can_failover].nil? || !!sentinel[:can_failover] ? "yes" : "no"  %>
+sentinel parallel-syncs <%= sentinel[:master_name] %> <%= sentinel[:parallel_syncs] || 1 %>
+<% end %>
+
+
+# Redis configuration file example
+
+# Note on units: when memory size is needed, it is possible to specifiy
+# it in the usual form of 1k 5GB 4M and so forth:
+#
+# 1k => 1000 bytes
+# 1kb => 1024 bytes
+# 1m => 1000000 bytes
+# 1mb => 1024*1024 bytes
+# 1g => 1000000000 bytes
+# 1gb => 1024*1024*1024 bytes
+#
+# units are case insensitive so 1GB 1Gb 1gB are all the same.
+
+# By default Redis does not run as a daemon. Use 'yes' if you need it.
+# Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
+<% unless @job_control == 'upstart' %> 
+daemonize yes
+<% end %>
+
+# When running daemonized, Redis writes a pid file in /var/run/redis.pid by
+# default. You can specify a custom pid file location here.
+pidfile <%= @piddir %>/redis_<%=@name%>.pid
+
+# Accept connections on the specified port, default is 6379.
+# If port 0 is specified Redis will not listen on a TCP socket.
+port <%=@port%>
+
+# If you want you can bind a single interface, if the bind option is not
+# specified all the interfaces will listen for incoming connections.
+#
+# bind 127.0.0.1
+<% unless @address.nil? %>
+  <%= "bind #{@address.respond_to?(:join) ? @address.join(" ") : @address }" %>
+<% end %>
+
+# Specify the path for the unix socket that will be used to listen for
+# incoming connections. There is no default, so Redis will not listen
+# on a unix socket when not specified.
+#
+# unixsocket /tmp/redis.sock
+# unixsocketperm 755
+<%= "unixsocket #{@unixsocket}" unless @unixsocket.nil? %>
+<%= "unixsocketperm #{@unixsocketperm}" unless @unixsocketperm.nil? %>
+
+# Close the connection after a client is idle for N seconds (0 to disable)
+<%= "timeout #{@timeout}" %>
+
+# Set server verbosity to 'debug'
+# it can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+loglevel <%=@loglevel%>
+
+# Specify the log file name. Also 'stdout' can be used to force
+# Redis to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+#
+# In version of redis 2.8 and higher to log to stdout use the empty
+# string instead of "stdout"
+#
+# logfile stdout
+<%= "logfile #{@logfile}" unless @logfile.nil? %>
+
+# To enable logging to the system logger, just set 'syslog-enabled' to yes,
+# and optionally update the other syslog parameters to suit your needs.
+syslog-enabled <%= "#{@syslogenabled}" %>
+
+# Specify the syslog identity.
+syslog-ident redis-<%=@name%>
+
+# Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
+syslog-facility <%= "#{@syslogfacility}" %>
+
+
+################################## SECURITY ###################################
+
+# Require clients to issue AUTH <PASSWORD> before processing any other
+# commands.  This might be useful in environments in which you do not trust
+# others with access to the host running redis-server.
+#
+# This should stay commented out for backward compatibility and because most
+# people do not need auth (e.g. they run their own servers).
+# 
+# Warning: since Redis is pretty fast an outside user can try up to
+# 150k passwords per second against a good box. This means that you should
+# use a very strong password otherwise it will be very easy to break.
+#
+# requirepass foobared
+<%= "requirepass #{@requirepass}" unless @requirepass.nil? %>
+
+# Command renaming.
+#
+# It is possilbe to change the name of dangerous commands in a shared
+# environment. For instance the CONFIG command may be renamed into something
+# of hard to guess so that it will be still available for internal-use
+# tools but not available for general clients.
+#
+# Example:
+#
+# rename-command CONFIG b840fc02d524045429941cc15f59e41cb7be6c52
+#
+# It is also possilbe to completely kill a command renaming it into
+# an empty string:
+#
+# rename-command CONFIG ""
+
+################################### LIMITS ####################################
+
+# Set the max number of connected clients at the same time. By default there
+# is no limit, and it's up to the number of file descriptors the Redis process
+# is able to open. The special value '0' means no limits.
+# Once the limit is reached Redis will close all the new connections sending
+# an error 'max number of clients reached'.
+#
+<%= "maxclients #{@maxclients}" %>
+
+# Don't use more memory than the specified amount of bytes.
+# When the memory limit is reached Redis will try to remove keys
+# accordingly to the eviction policy selected (see maxmemmory-policy).
+#
+# If Redis can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', Redis will start to reply with errors to commands
+# that would use more memory, like SET, LPUSH, and so on, and will continue
+# to reply to read-only commands like GET.
+#
+# This option is usually useful when using Redis as an LRU cache, or to set
+# an hard memory limit for an instance (using the 'noeviction' policy).
+#
+# WARNING: If you have slaves attached to an instance with maxmemory on,
+# the size of the output buffers needed to feed the slaves are subtracted
+# from the used memory count, so that network problems / resyncs will
+# not trigger a loop where keys are evicted, and in turn the output
+# buffer of slaves is full with DELs of keys evicted triggering the deletion
+# of more keys, and so forth until the database is completely emptied.
+#
+# In short... if you have slaves attached it is suggested that you set a lower
+# limit for maxmemory so that there is some free RAM on the system for slave
+# output buffers (but this is not needed if the policy is 'noeviction').
+#
+#maxmemory <bytes>
+<%= "maxmemory #{@maxmemory}" unless @maxmemory.empty? %>
+
+# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
+# is reached? You can select among five behavior:
+# 
+# volatile-lru -> remove the key with an expire set using an LRU algorithm
+# allkeys-lru -> remove any key accordingly to the LRU algorithm
+# volatile-random -> remove a random key with an expire set
+# allkeys->random -> remove a random key, any key
+# volatile-ttl -> remove the key with the nearest expire time (minor TTL)
+# noeviction -> don't expire at all, just return an error on write operations
+# 
+# Note: with all the kind of policies, Redis will return an error on write
+#       operations, when there are not suitable keys for eviction.
+#
+#       At the date of writing this commands are: set setnx setex append
+#       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
+#       sinter sinterstore sunion sunionstore sdiff sdiffstore zadd zincrby
+#       zunionstore zinterstore hset hsetnx hmset hincrby incrby decrby
+#       getset mset msetnx exec sort
+#
+# The default is:
+#
+# maxmemory-policy volatile-lru
+<%= "maxmemory-policy #{@maxmemorypolicy}" unless @maxmemorypolicy.nil? %>
+
+# LRU and minimal TTL algorithms are not precise algorithms but approximated
+# algorithms (in order to save memory), so you can select as well the sample
+# size to check. For instance for default Redis will check three keys and
+# pick the one that was used less recently, you can change the sample size
+# using the following configuration directive.
+#
+# maxmemory-samples 3
+maxmemory-samples <%=@maxmemorysamples%>
+
+
+################################## SLOW LOG ###################################
+
+# The Redis Slow Log is a system to log queries that exceeded a specified
+# execution time. The execution time does not include the I/O operations
+# like talking with the client, sending the reply and so forth,
+# but just the time needed to actually execute the command (this is the only
+# stage of command execution where the thread is blocked and can not serve
+# other requests in the meantime).
+# 
+# You can configure the slow log with two parameters: one tells Redis
+# what is the execution time, in microseconds, to exceed in order for the
+# command to get logged, and the other parameter is the length of the
+# slow log. When a new command is logged the oldest one is removed from the
+# queue of logged commands.
+
+# The following time is expressed in microseconds, so 1000000 is equivalent
+# to one second. Note that a negative number disables the slow log, while
+# a value of zero forces the logging of every command.
+slowlog-log-slower-than 10000
+
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the slow log with SLOWLOG RESET.
+slowlog-max-len 1024
+
+<% unless @version[:major].to_i == 2 && @version[:minor].to_i >= 5 %> 
+################################ VIRTUAL MEMORY ###############################
+
+### WARNING! Virtual Memory is deprecated in Redis 2.4
+### The use of Virtual Memory is strongly discouraged.
+
+# Virtual Memory allows Redis to work with datasets bigger than the actual
+# amount of RAM needed to hold the whole dataset in memory.
+# In order to do so very used keys are taken in memory while the other keys
+# are swapped into a swap file, similarly to what operating systems do
+# with memory pages.
+#
+# To enable VM just set 'vm-enabled' to yes, and set the following three
+# VM parameters accordingly to your needs.
+
+vm-enabled no
+# vm-enabled yes
+
+# This is the path of the Redis swap file. As you can guess, swap files
+# can't be shared by different Redis instances, so make sure to use a swap
+# file for every redis process you are running. Redis will complain if the
+# swap file is already in use.
+#
+# The best kind of storage for the Redis swap file (that's accessed at random) 
+# is a Solid State Disk (SSD).
+#
+# *** WARNING *** if you are using a shared hosting the default of putting
+# the swap file under /tmp is not secure. Create a dir with access granted
+# only to Redis user and configure Redis to create the swap file there.
+vm-swap-file /tmp/redis.swap
+
+# vm-max-memory configures the VM to use at max the specified amount of
+# RAM. Everything that deos not fit will be swapped on disk *if* possible, that
+# is, if there is still enough contiguous space in the swap file.
+#
+# With vm-max-memory 0 the system will swap everything it can. Not a good
+# default, just specify the max amount of RAM you can in bytes, but it's
+# better to leave some margin. For instance specify an amount of RAM
+# that's more or less between 60 and 80% of your free RAM.
+vm-max-memory 0
+
+# Redis swap files is split into pages. An object can be saved using multiple
+# contiguous pages, but pages can't be shared between different objects.
+# So if your page is too big, small objects swapped out on disk will waste
+# a lot of space. If you page is too small, there is less space in the swap
+# file (assuming you configured the same number of total swap file pages).
+#
+# If you use a lot of small objects, use a page size of 64 or 32 bytes.
+# If you use a lot of big objects, use a bigger page size.
+# If unsure, use the default :)
+vm-page-size 32
+
+# Number of total memory pages in the swap file.
+# Given that the page table (a bitmap of free/used pages) is taken in memory,
+# every 8 pages on disk will consume 1 byte of RAM.
+#
+# The total swap size is vm-page-size * vm-pages
+#
+# With the default of 32-bytes memory pages and 134217728 pages Redis will
+# use a 4 GB swap file, that will use 16 MB of RAM for the page table.
+#
+# It's better to use the smallest acceptable value for your application,
+# but the default is large in order to work in most conditions.
+vm-pages 134217728
+
+# Max number of VM I/O threads running at the same time.
+# This threads are used to read/write data from/to swap file, since they
+# also encode and decode objects from disk to memory or the reverse, a bigger
+# number of threads can help with big objects even if they can't help with
+# I/O itself as the physical device may not be able to couple with many
+# reads/writes operations at the same time.
+#
+# The special value of 0 turn off threaded I/O and enables the blocking
+# Virtual Memory implementation.
+vm-max-threads 4
+<% end %>
+
+################################## INCLUDES ###################################
+
+# Include one or more other config files here.  This is useful if you
+# have a standard template that goes to all redis server but also need
+# to customize a few per-server settings.  Include files can include
+# other files, so use this wisely.
+#
+# include /path/to/local.conf
+# include /path/to/other.conf
+<% unless @includes.nil? %>
+  <% @includes.each do |include_option| %>
+    <%= "include #{include_option}" %>
+  <% end %>
+<% end %>
+

--- a/templates/default/redis-sentinel.init.erb
+++ b/templates/default/redis-sentinel.init.erb
@@ -1,0 +1,75 @@
+#!/bin/sh
+#
+# Simple Redis init.d script conceived to work on Linux systems
+# as it does use of the /proc filesystem.
+#
+# description: Redis is an in memory key-value store database
+#
+### BEGIN INIT INFO
+# Provides: redis<%= @port %>
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Description: redis<%= @port %> init script
+### END INIT INFO
+
+REDISNAME=<%= @name %>
+REDISPORT=<%= @port %>
+<% case @platform %>
+<% when 'ubuntu','debian','fedora' %>
+EXEC="sudo -u <%= @user %> <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/${REDISNAME}.conf --sentinel "
+<% else %> 
+EXEC="runuser <%= @user %> -c \"<%= File.join(@bin_path, 'redis-server') %> --sentinel <%= @configdir %>/${REDISNAME}.conf\""
+<% end %>
+CLIEXEC=<%= File.join(@bin_path, 'redis-cli') %>
+
+<% connection_string = String.new %>
+<% if @unixsocket.nil? %> 
+  <% connection_string << " -p #{@port}" %>
+  <% connection_string << " -h #{@address.respond_to?(:first) ? @address.first : @address }" if @address %>
+<% else %>
+  <% connection_string << " -s #{@unixsocket}" %>
+<% end %>
+<% connection_string  << " -a '#{@requirepass}'" unless @requirepass.nil? %>  
+
+PIDFILE=<%= @piddir %>/redis_${REDISNAME}.pid
+
+if [ ! -d <%= @piddir %> ]; then
+    mkdir -p <%= @piddir %>
+    chown <%= @user %>  <%= @piddir %>
+fi
+
+ulimit -n <%= @ulimit %>
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis server..."
+                eval $EXEC
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+
+                <%= "$CLIEXEC #{connection_string} save" if @shutdown_save %>                 
+                $CLIEXEC <%= connection_string %> shutdown
+
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    *)
+        echo "Please use start or stop as first argument"
+        ;;
+esac

--- a/templates/default/redis-sentinel.upstart.conf.erb
+++ b/templates/default/redis-sentinel.upstart.conf.erb
@@ -1,0 +1,19 @@
+description "Start the redis instance on port <%= @port %>"
+author "Installed by chef redisio cookbook"
+
+#start on runlevel [2345]
+stop on runlevel [06]
+
+script
+  if [ ! -d <%= @piddir %> ]; then
+    mkdir -p <%= @piddir %>
+    chown <%= @user %>:<%= @group %>  <%= @piddir %>
+  fi
+end script
+
+# If the job exits, restart it. Give up with more than 10 restarts in 30 seconds.
+respawn
+respawn limit 10 30
+
+exec su -s /bin/sh -c 'exec "$0" "$@"' <%= @user %> /usr/local/bin/redis-server --sentinel <%= @configdir %>/<%= @name %>.conf
+


### PR DESCRIPTION
Hello,

first I need to say: "I love your cookbook for redis" :+1: 

but I am using redis-sentinel for failover so I tried to implement starting and configuring redis sentinel by your cookbook.

This pull request contains changes for adding support of sentinel.

see http://redis.io/topics/sentinel

Sorry for my english and I hope I don;t have any error in it. But I tested it in vagrant precise64.box and it worked flawlessly

Ondrej Bartas
