### PR TITLE
Fix insserv warning

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -7,6 +7,8 @@
 #
 ### BEGIN INIT INFO
 # Provides: redis<%= @port %>
+# Required-Start: $remote_fs $network
+# Required-Stop: $remote_fs $network
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Description: redis<%= @port %> init script


### PR DESCRIPTION
Insserv issues warning on update-rc.d:

insserv: Script redis6379 is broken: incomplete LSB comment.
insserv: missing `Required-Start:' entry: please add even if empty.
insserv: missing`Required-Stop:'  entry: please add even if empty.
