### PR TITLE
comment sentinel can-failover since it gives error on sentinel_enable recipe

### DIFF
--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -53,7 +53,8 @@ sentinel down-after-milliseconds <%=@name%> <%=@downaftermil%>
 # sentinel can-failover <master-name> <yes|no>
 #
 # Specify if this Sentinel can start the failover for this master.
-sentinel can-failover <%=@name%> <%=@canfailover%>
+# currently this option doesn't work with redis-server 2.8.1
+# sentinel can-failover <%=@name%> <%=@canfailover%>
 
 # sentinel parallel-syncs <master-name> <numslaves>
 #


### PR DESCRIPTION
Currently I can't see why, but I needed to comment `sentinel can-failover` option to make it work.

I use following configuration:
- CentOS 6.3
- redis 2.8.1

What do you think about it ?
