### PR TITLE
Fix bug with nil file resource for logfile.

### DIFF
--- a/providers/install.rb
+++ b/providers/install.rb
@@ -135,13 +135,15 @@ def configure
         only_if { current['syslogenabled'] != 'yes' && current['logfile'] && current['logfile'] != 'stdout' }
       end
       #Create the log file is syslog is not being used
-      file current['logfile'] do
-        owner current['user']
-        group current['group']
-        mode '0644'
-        backup false
-        action :touch
-        only_if { current['logfile'] && current['logfile'] != 'stdout' }
+      if current['logfile']
+          file current['logfile'] do
+            owner current['user']
+            group current['group']
+            mode '0644'
+            backup false
+            action :touch
+            only_if { current['logfile'] != 'stdout' }
+          end
       end
       #Set proper permissions on the AOF or RDB files
       file aof_file do


### PR DESCRIPTION
This bug was introduced because Chef now checks that file resource
names are not nil.

See: https://github.com/opscode/chef/commit/b4c8facbf495423950345937ab4a8d6d8792ad16#diff-777c3a72344547b365dc6149ec4ebaffR111

This was the error encountered:

```
================================================================================
Error executing action `run` on resource 'redisio_install[redis-servers]'
================================================================================


ArgumentError
-------------
You must supply a name when declaring a file resource


Cookbook Trace:
---------------
/tmp/kitchen/cookbooks/redisio/providers/install.rb:138:in `block (2 levels) in configure'
/tmp/kitchen/cookbooks/redisio/providers/install.rb:90:in `block in configure'
```
