### PR TITLE
init script: Call "shutdown save"

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -58,8 +58,7 @@ case "$1" in
                 PID=$(cat $PIDFILE)
                 echo "Stopping ..."
 
-                <%= "$CLIEXEC #{connection_string} save" if @shutdown_save %>                 
-                $CLIEXEC <%= connection_string %> shutdown
+                $CLIEXEC <%= connection_string %> shutdown <%= "save" if @shutdown_save %>
 
                 while [ -x /proc/${PID} ]
                 do


### PR DESCRIPTION
If persistence is enabled this commands makes sure that Redis is switched off without the lost of any data. This is not guaranteed if the client uses simply SAVE and then QUIT because other clients may alter the DB data between the two commands.
