### PR TITLE
Completing debian LSB start/stop script

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -7,6 +7,8 @@
 #
 ### BEGIN INIT INFO
 # Provides: redis<%= @port %>
+# Required-Start: $local_fs $remote_fs $network $syslog
+# Required-Stop: $local_fs $remote_fs $network $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Required-Start: <%= @required_start %>


### PR DESCRIPTION
When you exec 'update-rc.d' or 'insserv', you obtain:

```
insserv: Script redis6379 is broken: incomplete LSB comment.
insserv: missing `Required-Start:' entry: please add even if empty.
insserv: missing `Required-Stop:'  entry: please add even if empty.
```

I have only added "Required-Start:" and "Required-Stop:" entries
