### PR TITLE
Adding all LSB comments in redis.init.erb

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -7,8 +7,12 @@
 #
 ### BEGIN INIT INFO
 # Provides: redis<%= @port %>
+# Required-Start:    
+# Required-Stop:     
+# Should-Start:      
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
+# Short-Description:
 # Description: redis<%= @port %> init script
 ### END INIT INFO
 


### PR DESCRIPTION
Adding LSB comments, insserv is saying they should be there even when empty
# Required-Start:
# Required-Stop:
# Should-Start:
# Short-Description:
