### PR TITLE
Missing default for sentinel setting, causes empty file resource name

### DIFF
--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -24,8 +24,8 @@ default['redisio']['sentinel_defaults'] = {
   'down-after-milliseconds' => 30000,
   'can-failover'            => 'yes',
   'parallel-syncs'          => 1,
-  'failover-timeout'        => 900000
+  'failover-timeout'        => 900000,
+  'logfile'                 => 'syslog'
 }
 
 default['redisio']['sentinels'] = []
-


### PR DESCRIPTION
Hello! This PR addresses a missing default, that if omitted by downstream causes a file resource with an empty string as the name:

```
      file current['logfile'] do
        owner current['user']
        group current['group']
        mode '0644'
        backup false
        action :touch
        only_if { current['logfile'] && current['logfile'] != 'stdout' }
      end
```

Due to the way chef parses resources, `current['logfile']` has to exist to create the resource, which all happens long before `only_if { current['logfile'] && current['logfile'] != 'stdout' }` is evaluated.
