### PR TITLE
allow sentinel manage_config attribute to control both redis configs as ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The disable recipe just stops redis and removes it from run levels.
 
 The cookbook also contains a recipe to allow for the installation of the redis ruby gem. 
 
-Redis-sentinel will write configuration and state data back into its configuration file.  This creates obvious problems when that config is managed by chef.  There is an attribute set to false which controls if chef manages the redis-sentinel config.  By default chef will write out this config file once and then leave it in the hands of sentinel to manage.  If needed you can set the node[:redis][:sentinel][:manage_config] to true if you would like chef to manage this config.  This is only advised for when you are pushing new changes to the config file as it will create a flapping state between chef and sentinel when sentinel writes out state to the file.
+Redis-sentinel will write configuration and state data back into its configuration file.  This creates obvious problems when that config is managed by chef.  There is an attribute set to true which controls if chef manages the redis-sentinel config.  By default chef will write out this config file and manage it.  If deploying sentenel it is recommened that you set the node[:redis][:sentinel][:manage_config] to false allowing chef to write out the initial config and then allow redis-sentiniel to manage.  If running sentinel it is only advices to have node[:redis][:sentinel][:manage_config] = true when you are pushing new changes to the config file as it will create a flapping state between chef and sentinel when sentinel writes out state to the file.
 
 Recipes
 -------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,10 +52,6 @@ default['redisio']['job_control'] = 'initd'
 default['redisio']['init.d']['required_start'] = []
 default['redisio']['init.d']['required_stop'] = []
 
-# Manage Sentinel Config File
-## Will write out the base config one time then no longer manage the config allowing sentinel to take over
-default['redisio']['manage_config'] = false
-
 # Default settings for all redis instances, these can be overridden on a per server basis in the 'servers' hash
 default['redisio']['default_settings'] = {
   'user'                    => 'redis',

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 redisio CHANGE LOG
 ===
+2.2.1 -
+---
+  - Allow sentinel to control both redis and redis-sentinel configs depending on attribute `redisio.sentinel.manage_config` state.
 
 2.2.0 -
 ---

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'brian.bianco@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures redis'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.0'
+version          '2.2.1'
 %w[ debian ubuntu centos redhat fedora scientific suse amazon].each do |os|
   supports os
 end

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -79,7 +79,7 @@ def configure
     descriptors = current['ulimit'] == 0 ? current['maxclients'] + 32 : current['maxclients']
 
     #Manage Redisio Config?
-    if node['redisio']['manage_config'] == true
+    if node['redisio']['sentinel']['manage_config'] == true
       config_action = :create
     else
       config_action = :create_if_missing


### PR DESCRIPTION
allow sentinel manage_config attribute to control both redis configs as sentinel is responsible for updating both configs upon state change.

There was some talk on flipping the attribute to false upon including the sentinel_enable recipe.  I am not sold on that just yet.  Will need to put some more thought on if we want to control this attribute via inclusion of the sentinel enable recipe or simply leave it up to the user to control.

Either way that is a small adjustment when we make that decision.

Improved readme slightly, bumped version + changelog. 
