### PR TITLE
Add tcp-keepalive to redis conf, set default to 0 per normal installation

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -188,6 +188,7 @@ def configure
           :unixsocket                 => current['unixsocket'],
           :unixsocketperm             => current['unixsocketperm'],
           :timeout                    => current['timeout'],
+          :keepalive                  => current['keepalive'],
           :loglevel                   => current['loglevel'],
           :logfile                    => current['logfile'],
           :syslogenabled              => current['syslogenabled'],


### PR DESCRIPTION
fixes #133 where keepalive option is not forwarded to template - thus preventing redis from starting up.
