### PR TITLE
Fixes no-tty error by adjusting sudo before tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,14 @@ platforms:
   - name: debian-6.0.8
   - name: centos-6.4
   - name: fedora-20
+    run_list:
+      - recipe[sudo]
+    attributes:
+      authorization:
+        sudo:
+          users: [ "vagrant" ]
+          passwordless: true
+# Fedora 20 requires a tty, hence the additional scaffolding
 
 suites:
   - name: default

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,3 +19,4 @@ recipe "redisio::redis_gem", "this recipe will install the redis ruby gem into t
 
 depends "ulimit", ">= 0.1.2"
 depends "build-essential"
+depends "sudo"


### PR DESCRIPTION
Fixes https://github.com/brianbianco/redisio/issues/137, adds the sudo cookbook and configures the vagrant user to be passwordless. By default, the sudo cookbook does not add the TTY requirement, so the regenerated /etc/sudoers is fixed after it runs.
