### PR TITLE
keyspace version conditional, actually use param

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -503,7 +503,7 @@ vm-pages 134217728
 vm-max-threads 4
 <% end %>
 
-<% unless @version[:major].to_i == 2 && @version[:minor].to_i >= 8 %>
+<% if @version[:major].to_i == 2 && @version[:minor].to_i >= 8 %>
 <% ######## Redis 2.8 and higher ######## %>
 ############################# Event notification ##############################
 


### PR DESCRIPTION
Introduced in 0d4553b and
brianbianco/redisio#106

This configuration item was introduced in the 2.8.x series of Redis, and
using the cookbook on older redis nodes breaks the configuration, as the
config is written and service startup is halted due to unrecognized
entry.

This also adds support for actually using the parameter passed, as
previously it remained an empty string no matter what you would pass to
the attribute.
