### PR TITLE
sentinel_port is not used consistently

### DIFF
--- a/recipes/sentinel.rb
+++ b/recipes/sentinel.rb
@@ -24,8 +24,8 @@ include_recipe 'ulimit::default'
 redis = node['redisio']
 
 sentinel_instances = redis['sentinels']
-if sentinel_instances.empty?
-  sentinel_instances = [{'port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => 6379}]
+if sentinel_instances && sentinel_instances.empty?
+  sentinel_instances = [{'sentinel_port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => '6379'}]
 end
 
 redisio_sentinel "redis-sentinels" do

--- a/recipes/sentinel_enable.rb
+++ b/recipes/sentinel_enable.rb
@@ -19,8 +19,8 @@
 #
 
 sentinel_instances = node['redisio']['sentinels']
-if sentinel_instances.empty?
-  sentinel_instances = [{'port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => 6379}]
+if sentinel_instances && sentinel_instances.empty?
+  sentinel_instances = [{'sentinel_port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => '6379'}]
 end
 
 sentinel_instances.each do |current_sentinel|


### PR DESCRIPTION
Walking back from `sentinel.conf.erb`, we see the template uses the following `sentinel_port` variable to assign a port to a sentinel instance in https://github.com/brianbianco/redisio/blob/master/templates/default/sentinel.conf.erb#L14-L16:

```
# port <sentinel-port>
# The port that this sentinel instance will run on
port <%=@sentinel_port%>
```

This is populated in the sentinel provider here https://github.com/brianbianco/redisio/blob/master/providers/sentinel.rb#L98-L123:

``` ruby
template "#{current['configdir']}/#{sentinel_name}.conf" do
source 'sentinel.conf.erb'
cookbook 'redisio'
owner current['user']
group current['group']
mode '0644'
action config_action
variables({
:piddir => piddir,
:name => sentinel_name,
:job_control => node['redisio']['job_control'],
:sentinel_port => current['sentinel_port'],
:masterip => current['master_ip'],
:masterport => current['master_port'],
:authpass => current['auth-pass'],
:downaftermil => current['down-after-milliseconds'],
:canfailover => current['can-failover'],
:parallelsyncs => current['parallel-syncs'],
:failovertimeout => current['failover-timeout'],
:loglevel => current['loglevel'],
:logfile => current['logfile'],
:syslogenabled => current['syslogenabled'],
:syslogfacility => current['syslogfacility'],
:quorum_count => current['quorum_count']
})
end
```

For a brand new sentinel with the defaults, one can call `redisio::sentinel` and get a default sentinel configured here https://github.com/brianbianco/redisio/blob/master/recipes/sentinel.rb#L26-L35:

``` ruby
sentinel_instances = redis['sentinels']
if sentinel_instances.empty?
  sentinel_instances = [{'port' => '26379', 'name' => 'mycluster', 'master_ip' => '127.0.0.1', 'master_port' => 6379}]
end

redisio_sentinel "redis-sentinels" do
  sentinel_defaults redis['sentinel_defaults']
  sentinels sentinel_instances
  base_piddir redis['base_piddir']
end
```

Note that the default sentinel instance has `'port' => '26379'`. This should read `'sentinel_port' => '26379'`. Since there is no way to override the default sentinel port, the mistake has gone unnoticed. PR for this incoming.
