### PR TITLE
Made redisio providers to correctly mark resource as changed.

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -18,9 +18,10 @@
 # limitations under the License.
 #
 
+use_inline_resources
+
 action :run do
   configure
-  new_resource.updated_by_last_action(true)
 end
 
 def configure
@@ -86,7 +87,6 @@ def configure
       config_action = :create_if_missing
     end
 
-    recipe_eval do
       server_name = current['name'] || current['port']
       piddir = "#{base_piddir}/#{server_name}"
       aof_file = "#{current['datadir']}/appendonly-#{server_name}.aof"
@@ -282,7 +282,6 @@ def configure
         })
         only_if { node['redisio']['job_control'] == 'upstart' }
       end
-    end
   end # servers each loop
 end
 

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -18,10 +18,11 @@
 # limitations under the License.
 #
 
-use_inline_resources
+use_inline_resources if respond_to?(:use_inline_resources)
 
 action :run do
   configure
+  new_resource.updated_by_last_action(true) unless respond_to?(:use_inline_resources)
 end
 
 def configure

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-use_inline_resources
+use_inline_resources if respond_to?(:use_inline_resources)
 
 action :run do
   @tarball = "#{new_resource.base_name}#{new_resource.version}.#{new_resource.artifact_type}"
@@ -28,6 +28,7 @@ action :run do
     unpack
     build
     install
+    new_resource.updated_by_last_action(true) unless respond_to?(:use_inline_resources)
   end
 end
 

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -1,4 +1,5 @@
 #
+#
 # Cookbook Name:: redisio
 # Provider::install
 #
@@ -16,6 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources
 
 action :run do
   @tarball = "#{new_resource.base_name}#{new_resource.version}.#{new_resource.artifact_type}"
@@ -27,7 +29,6 @@ action :run do
     build
     install
   end
-  new_resource.updated_by_last_action(true)
 end
 
 def download

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -16,10 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources
 
 action :run do
   configure
-  new_resource.updated_by_last_action(true)
 end
 
 def configure
@@ -42,7 +42,6 @@ def configure
       config_action = :create_if_missing
     end
 
-    recipe_eval do
       sentinel_name = current['name'] || current['port']
       sentinel_name = "sentinel_#{sentinel_name}"
       piddir = "#{base_piddir}/#{sentinel_name}"
@@ -159,7 +158,6 @@ def configure
           })
         only_if { node['redisio']['job_control'] == 'upstart' }
       end
-    end
   end # servers each loop
 end
 

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -16,10 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-use_inline_resources
+use_inline_resources if respond_to?(:use_inline_resources)
 
 action :run do
   configure
+  new_resource.updated_by_last_action(true) unless respond_to?(:use_inline_resources)
 end
 
 def configure


### PR DESCRIPTION
At the moment all redisio providers will send notifications that resource was changed that might result in unnecessary redis restarts.

I've removed few lines that forcibly mark resource as changed + added use_inline_resources which will rely on chef's provided resources logic to mark changed things.

There is one drawback - use_inline_resources was introduced in chef 11. 
