### PR TITLE
removing unecessary inclusion of the default recipe

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'brian.bianco@gmail.com'
 license          'Apache 2.0'
 description      'Installs/Configures redis'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.2.4'
+version          '2.2.5'
 %w[ debian ubuntu centos redhat fedora scientific suse amazon].each do |os|
   supports os
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-include_recipe 'redisio::default'
 include_recipe 'ulimit::default'
 
 redis = node['redisio']


### PR DESCRIPTION
This also resolved the ticket: Manually deleted the conf files. Now getting: Cannot find a resource matching service[redis6379](did you define it first?) #170
