### PR TITLE
Binary path issue and init function missing

### DIFF
--- a/templates/default/redis.init.erb
+++ b/templates/default/redis.init.erb
@@ -14,15 +14,22 @@
 # Description: redis<%= @port %> init script
 ### END INIT INFO
 
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+<% unless node[:redisio][:package_install] -%>
+export PATH=<%= default[:redisio][:bin_path] %>:$PATH
+<% end %>
+
 REDISNAME=<%= @name %>
 REDISPORT=<%= @port %>
 <% case @platform %>
 <% when 'ubuntu','debian','fedora' %>
-EXEC="su -s /bin/sh -c '<%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/${REDISNAME}.conf' <%= @user %>"
+EXEC="su -s /bin/sh -c 'redis-server <%= @configdir %>/${REDISNAME}.conf' <%= @user %>"
 <% else %>
-EXEC="runuser <%= @user %> -c \"<%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/${REDISNAME}.conf\""
+EXEC="runuser <%= @user %> -c \"redis-server <%= @configdir %>/${REDISNAME}.conf\""
 <% end %>
-CLIEXEC=<%= File.join(@bin_path, 'redis-cli') %>
+CLIEXEC=redis-cli
 
 <% connection_string = String.new %>
 <% if @unixsocket.nil? %>


### PR DESCRIPTION
Hi,

With some packaged version of Redis (2.4 for Centos6 for example) the redis-server and redis-cli are not in the same path which is a problem with the init script you provides as they are supposed to be in the same path.

Following the init convention (https://fedoraproject.org/wiki/Packaging:SysVInitScript), you do not load init functions which lead to missing variables like PATH.

What I suggest is to load this PATH by using init functions, stop using the binary full path in the init file and customize the PATH for customized versions. This resolve all those issues, I purpose this update of the init script to be much more clean and compliant.
