### PR TITLE
Do not take into account sentinel settings base redis instance

### DIFF
--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -86,13 +86,6 @@ def configure
 
     descriptors = current['ulimit'] == 0 ? current['maxclients'] + 32 : current['maxclients']
 
-    #Manage Redisio Config?
-    if node['redisio']['sentinel']['manage_config'] == true
-      config_action = :create
-    else
-      config_action = :create_if_missing
-    end
-
     recipe_eval do
       server_name = current['name'] || current['port']
       piddir = "#{base_piddir}/#{server_name}"


### PR DESCRIPTION
There is no need in not managing configuration for basic redisio, because they do not store configuration like sentinels
