### PR TITLE
Avoid using elevated normal precedence unless required

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -71,4 +71,4 @@ redis_instances.each do |current_server|
 
 end
 
-node.set['redisio']['servers'] = redis_instances
+node.default['redisio']['servers'] = redis_instances

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -20,17 +20,16 @@
 include_recipe 'redisio::default'
 include_recipe 'ulimit::default'
 
-redis = node['redisio']
-
-redis_instances = redis['servers']
-if redis_instances.nil?
-  redis_instances = [{'port' => '6379'}]
+if node['redisio']['servers'].nil?
+  node.default['redisio']['servers'] = [{'port' => '6379'}]
 end
+
+redis = node['redisio']
 
 redisio_configure "redis-servers" do
   version redis['version'] if redis['version']
   default_settings redis['default_settings']
-  servers redis_instances
+  servers redis['servers']
   base_piddir redis['base_piddir']
 end
 
@@ -41,7 +40,7 @@ template '/usr/lib/systemd/system/redis@.service' do
 end
 
 # Create a service resource for each redis instance, named for the port it runs on.
-redis_instances.each do |current_server|
+redis['servers'].each do |current_server|
   server_name = current_server['name'] || current_server['port']
   job_control = node['redisio']['job_control']
 
@@ -70,5 +69,3 @@ redis_instances.each do |current_server|
   end
 
 end
-
-node.default['redisio']['servers'] = redis_instances


### PR DESCRIPTION
https://github.com/brianbianco/redisio/blob/d34858583753ba61923795b41619089c65802366/recipes/configure.rb#L74

Seems that the above isn't strictly necessary, right? Even if set to default, the setting in recipe takes precedence over the setting in the attributes file (the nil value).

I only ask, as I believe it's a common pattern to reserve "normal" level precedence for manual tuning of the node object. (It's convenient as `knife node edit` by default just shows the normal level attributes, and hides the noise of default and override level)

Any thoughts or objections to my submitting a PR to move from `node.set` to `node.default`? :)
