### PR TITLE
Increases clustertimeout from 5 to 5000

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Available options and their defaults
 'aofrewriteincrementalfsync' => 'yes',
 'cluster-enabled'            => 'no',
 'cluster-config-file'        => nil, # Defaults to redis instance name inside of template if cluster is enabled.
-'cluster-node-timeout'       => 5,
+'cluster-node-timeout'       => 5000,
 'includes'                   => nil
 ```
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,7 +129,7 @@ default['redisio']['default_settings'] = {
   'aofrewriteincrementalfsync' => 'yes',
   'clusterenabled'            => 'no',
   'clusterconfigfile'        => nil, # Defaults to redis instance name inside of template if cluster is enabled.
-  'clusternodetimeout'       => 5,
+  'clusternodetimeout'       => 5000,
   'includes'                   => nil
 }
 


### PR DESCRIPTION
The default timeout should be 5 seconds, currently is it misconfigured for 5 milliseconds
See conversation in #242
