### PR TITLE
Simplify upstart files by removing unused piddir code

### DIFF
--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -18,6 +18,7 @@
 
 default['redisio']['sentinel_defaults'] = {
   'user'                    => 'redis',
+  'group'                   => 'redis',
   'configdir'               => '/etc/redis',
   'sentinel_port'           => 26379,
   'monitor'                 => nil,

--- a/templates/default/redis.upstart.conf.erb
+++ b/templates/default/redis.upstart.conf.erb
@@ -4,16 +4,11 @@ author "Installed by chef redisio cookbook"
 #start on runlevel [2345]
 stop on runlevel [06]
 
-script
-  if [ ! -d <%= @piddir %> ]; then
-    mkdir -p <%= @piddir %>
-    chown <%= @user %>:<%= @group %>  <%= @piddir %>
-  fi
-end script
-
 # If the job exits, restart it. Give up with more than 10 restarts in 30 seconds.
 respawn
 respawn limit 10 30
 
-exec su -s /bin/sh -c 'exec "$0" "$@"' <%= @user %> <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/<%= @name %>.conf
+setuid <%= @user %>
+setgid <%= @group %>
 
+exec <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/<%= @name %>.conf

--- a/templates/default/sentinel.upstart.conf.erb
+++ b/templates/default/sentinel.upstart.conf.erb
@@ -4,16 +4,11 @@ author "Installed by chef redisio cookbook"
 #start on runlevel [2345]
 stop on runlevel [06]
 
-script
-  if [ ! -d <%= @piddir %> ]; then
-    mkdir -p <%= @piddir %>
-    chown <%= @user %>:<%= @group %>  <%= @piddir %>
-  fi
-end script
-
 # If the job exits, restart it. Give up with more than 10 restarts in 30 seconds.
 respawn
 respawn limit 10 30
 
-exec su -s /bin/sh -c 'exec "$0" "$@"' -- <%= @user %> <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/<%= @name %>.conf --sentinel
+setuid <%= @user %>
+setgid <%= @group %>
 
+exec <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/<%= @name %>.conf --sentinel


### PR DESCRIPTION
I have played with upstart support in v2.4.2 and came to the conclusion that the current upstart files could be simplified by removing the dead code related to the pid-dir creation.

As documented in the [redis.conf](https://github.com/brianbianco/redisio/blob/2.4.2/templates/default/redis.conf.erb#L21-L22) generated by this cookbook and in redis' own [code](https://github.com/antirez/redis/blob/2.8/src/redis.c#L3363), pidfiles are only created when running in daemonized mode, which is only the case for of the `initd` job_control method but not of the `upstart` one.

Because redis won't create pidfiles when managed by upstart, the pre-start script that creates the pid directories in `/var/run` can be removed, and so can the workaround to create those directories as root while execing the redis process as user redis; we can now free to use the standard setuid/setgid upstart stanzas.

After applying this PR, the redis server and sentinel processes will still run as the redis user and group, but they will have a much cleaner process tree, as shown below:

``` sh
# before
root      8029  0.0  0.2  63756  3276 ?        Ss   08:13   0:00 su -s /bin/sh -c exec "$0" "$@" redis /usr/local/bin/redis-server /etc/redis/one.conf
redis     8031  0.0  0.6  38048  9464 ?        Ssl  08:13   0:00 /usr/local/bin/redis-server *:6390
# after
root@backends-ubuntu-1404:~# ps aux | grep redis
redis     8051  0.0  0.5  35196  9080 ?        Ssl  08:20   0:00 /usr/local/bin/redis-server *:6390
```
