### PR TITLE
Adding expect fork in upstart service

### DIFF
--- a/templates/default/redis.upstart.conf.erb
+++ b/templates/default/redis.upstart.conf.erb
@@ -14,6 +14,7 @@ end script
 # If the job exits, restart it. Give up with more than 10 restarts in 30 seconds.
 respawn
 respawn limit 10 30
+expect fork
 
 exec su -s /bin/sh -c 'exec "$0" "$@"' <%= @user %> <%= File.join(@bin_path, 'redis-server') %> <%= @configdir %>/<%= @name %>.conf
 


### PR DESCRIPTION
When using upstart job_control, get following error. This results in ambiguous status.

```
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18132]: WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18132]: The server is now ready to accept connections on port 6379
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX kernel: [ 2547.421719] init: redistesting main process ended, respawning
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18137]: Creating Server TCP listening socket *:6379: bind: Address already in use
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX kernel: [ 2547.435435] init: redistesting main process ended, respawning
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18141]: Creating Server TCP listening socket *:6379: bind: Address already in use
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX kernel: [ 2547.451350] init: redistesting main process ended, respawning
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18145]: Creating Server TCP listening socket *:6379: bind: Address already in use
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX kernel: [ 2547.466029] init: redistesting main process ended, respawning
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18149]: Creating Server TCP listening socket *:6379: bind: Address already in use
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX kernel: [ 2547.480576] init: redistesting main process ended, respawning
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX redis-testing[18153]: Creating Server TCP listening socket *:6379: bind: Address already in use
Sep 30 05:52:14 ip-XXX-XX-XX-XXXX kernel: [ 2547.495252] init: redistesting main process ended, respawning
```

Adding `expect fork` solves the issue.
