### PR TITLE
Start Redis after network is up

### DIFF
--- a/templates/default/redis@.service.erb
+++ b/templates/default/redis@.service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description=Redis (%i) persistent key-value database
-After=network.target
+After=network.target network-online.target
+Requires=network-online.target
 
 [Service]
 ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize no


### PR DESCRIPTION
If Redis binded to specific IP, that uses bridged interface, for example, Redis fails to start.
Systemd will start redis after completely  started network service.