### PR TITLE
start service after network-online.target

### DIFF
--- a/templates/default/redis@.service.erb
+++ b/templates/default/redis@.service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description=Redis (%i) persistent key-value database
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize no


### PR DESCRIPTION
Current configuration does not work for cases when redis is bided to network interface which is initialized with some delay.
In my case my server is connected with another server via dedicated LAN cable which forms additional network. When I bind redis to this network it fails to start after reboot.