### PR TITLE
some much needed cleanup and CI fixes

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: 12.19.36
+  chef_version: 13
   # chef_version: current
 
 transport:
@@ -9,7 +9,8 @@ transport:
 
 provisioner:
   name: dokken
-  require_chef_omnibus: 12.19.36
+  product_name: chef
+  product_version: 13.3.0
 
 # TODO: uncomment after converting to inspec
 # verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,8 +11,7 @@ provisioner:
 platforms:
 <%
   chef_versions = %w(
-    11.0.0
-    12.19.36
+    13.3.0
     latest
   )
 
@@ -33,7 +32,8 @@ platforms:
   - name: <%= platform_version %>-<%= chef_version %>
     driver_config:
       box: bento/<%= platform_version %>
-      require_chef_omnibus: <%= chef_version %>
+      product_name: chef
+      product_version: <%= chef_version %>
     <% if platform_version == 'debian-7.11' %>
     # Set due to https://github.com/test-kitchen/kitchen-vagrant/issues/293
     driver:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,10 @@ Style/SpaceAroundOperators:
 
 Style/SymbolArray:
   EnforcedStyle: brackets
+
+# matching cookstyle eventually we should transition but babby steps
+Style/SafeNavigation:
+  Enabled: false
+
+Style/MixinUsage:
+  Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,8 @@
-source "https://supermarket.getchef.com"
+source 'https://supermarket.getchef.com'
 
 metadata
 
-cookbook "ulimit", ">= 0.1.2"
-cookbook "build-essential"
-cookbook "yum-epel"
-cookbook "yum-remi"
+cookbook 'ulimit', '>= 0.1.2'
+cookbook 'build-essential'
+cookbook 'yum-epel'
+cookbook 'yum-remi'

--- a/Cheffile
+++ b/Cheffile
@@ -1,5 +1,4 @@
 site 'http://community.opscode.com/api/v1'
 
-cookbook 'ulimit',                :git => 'git@github.com:bmhatfield/chef-ulimit', :ref => 'v0.3.1'
-cookbook 'build-essential',       :git => 'git@github.com:opscode-cookbooks/build-essential', :ref => 'v1.4.2'
-
+cookbook 'ulimit',                git: 'git@github.com:bmhatfield/chef-ulimit', ref: 'v0.3.1'
+cookbook 'build-essential',       git: 'git@github.com:opscode-cookbooks/build-essential', ref: 'v1.4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ group :testing do
   gem 'chefspec'
   gem 'foodcritic'
   gem 'rake'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.59.0'
+  gem 'cucumber-core', '~> 3.2'
 end
 
 group :travis_integration do

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-# Encoding: utf-8
 require 'bundler/setup'
 
 namespace :style do
@@ -20,10 +19,13 @@ namespace :style do
     t.options = {
       :search_gems => true,
       :fail_tags => ['correctness'],
-      :chef_version => '11.6.0',
+      :chef_version => '13.3.0',
+      # TODO: come back and remove foodcritic checks for cookbooks when we drop chef 13 support
       :tags => %w(
         ~FC059
         ~FC085
+        ~FC121
+        ~FC122
       )
     }
     # rubocop:enable Style/HashSyntax
@@ -36,7 +38,7 @@ task style: ['style:chef', 'style:ruby']
 desc 'Destroy test kitchen instances'
 task :destroy do
   Kitchen.logger = Kitchen.default_file_logger
-  Kitchen::Config.new.instances.each do |instance|
+  Kitchen::Config.new.instances.each do |instance| # rubocop:disable Style/SymbolProc
     instance.destroy
   end
 end

--- a/Thorfile
+++ b/Thorfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'bundler'
 require 'bundler/setup'
 require 'berkshelf/thor'
@@ -8,5 +6,5 @@ begin
   require 'kitchen/thor_tasks'
   Kitchen::ThorTasks.new
 rescue LoadError
-  puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV['CI']
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,39 +1,45 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = '2'.freeze
 
-base_box         = "precise32"
-url              = "http://files.vagrantup.com/precise32.box"
-cookbooks_path   = ["../","cookbooks/"]
-chef_upgrade     = %q{ which apt-get > /dev/null 2>&1 && apt-get install curl --yes
-                   gem install chef --no-rdoc --no-ri }
+base_box         = 'precise32'
+url              = 'http://files.vagrantup.com/precise32.box'
+cookbooks_path   = ['../', 'cookbooks/']
+chef_upgrade     = <<~CMD
+  which apt-get > /dev/null 2>&1 && apt-get install curl --yes
+  gem install chef --no-rdoc --no-ri
+CMD
 
-easy_run_solo    = %q{ echo "sudo chef-solo -c /tmp/vagrant-chef-1/solo.rb -j /tmp/vagrant-chef-1/dna.json" >  /home/vagrant/solo.sh
-                       chmod 775 /home/vagrant/solo.sh
-                       chown vagrant:vagrant /home/vagrant/solo.sh }
-
+solo_path        = '/tmp/vagrant-chef-1'.freeze
+easy_run_solo    = <<~CMD
+  echo 'sudo chef-solo -c #{solo_path}/solo.rb -j #{solo_path}/dna.json' >  /home/vagrant/solo.sh
+  chmod 775 /home/vagrant/solo.sh
+  chown vagrant:vagrant /home/vagrant/solo.sh
+CMD
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.berkshelf.berksfile_path = "./Berksfile"
+  config.berkshelf.berksfile_path = './Berksfile'
   config.berkshelf.enabled = true
 
   config.vm.define :redisio do |r|
     r.vm.box     = base_box
     r.vm.box_url = url
-    r.vm.network :private_network, :ip =>  "192.168.50.5"
-    r.vm.provision :shell, :inline => "sudo apt-get -y install build-essential"
-    r.vm.provision :shell, :inline => chef_upgrade
-    r.vm.provision :shell, :inline => easy_run_solo
+    r.vm.network :private_network, ip: '192.168.50.5'
+    r.vm.provision :shell, inline: 'sudo apt-get -y install build-essential'
+    r.vm.provision :shell, inline: chef_upgrade
+    r.vm.provision :shell, inline: easy_run_solo
 
     r.vm.provision :chef_solo do |chef|
       chef.cookbooks_path = cookbooks_path
-      chef.add_recipe "redisio::default"
-      chef.add_recipe "redisio::enable"
+      chef.add_recipe 'redisio::default'
+      chef.add_recipe 'redisio::enable'
       chef.json = {
         'redisio' => {
           'servers' => [
-            {'port' => 6379}
+            {
+              'port' => 6379
+            }
           ]
         }
       }
@@ -43,23 +49,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :sentinel do |s|
     s.vm.box     = base_box
     s.vm.box_url = url
-    s.vm.network :private_network, :ip => "192.168.50.10"
-    s.vm.provision :shell, :inline => "sudo apt-get -y install build-essential"
-    s.vm.provision :shell, :inline => chef_upgrade
-    s.vm.provision :shell, :inline => easy_run_solo
+    s.vm.network :private_network, ip: '192.168.50.10'
+    s.vm.provision :shell, inline: 'sudo apt-get -y install build-essential'
+    s.vm.provision :shell, inline: chef_upgrade
+    s.vm.provision :shell, inline: easy_run_solo
 
     s.vm.provision :chef_solo do |chef|
       chef.cookbooks_path = cookbooks_path
-      chef.add_recipe "redisio::sentinel"
-      chef.add_recipe "redisio::sentinel_enable"
+      chef.add_recipe 'redisio::sentinel'
+      chef.add_recipe 'redisio::sentinel_enable'
       chef.json = {
         'redisio' => {
           'sentinels' => [
-            {'sentinel_bind' => '0.0.0.0', 'sentinel_port' => 26379, 'name' => 'redisio', 'master_ip' => '192.168.50.5', 'master_port' => '6379'}
+            {
+              'sentinel_bind' => '0.0.0.0',
+              'sentinel_port' => 26379,
+              'name' => 'redisio',
+              'master_ip' => '192.168.50.5',
+              'master_port' => '6379'
+            }
           ]
         }
       }
     end
   end
-
 end

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # redisio CHANGE LOG
 
 ## Unreleased
+- drop chef support for versions `< 13.3`
+- pin rubocop gem to minor
+- appeased cops and critics
 
 ## 2.7.2 - Released 9/30/2018
 - fixes sentinal cluster init script by providing missing LSB statements ([#374])

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # redisio CHANGE LOG
 
 ## Unreleased
-- drop chef support for versions `< 13.3`
+- drop chef support for versions `< 13`
 - pin rubocop gem to minor
 - appeased cops and critics
 

--- a/libraries/redisio.rb
+++ b/libraries/redisio.rb
@@ -32,9 +32,7 @@ module RedisioHelper
     begin
       Chef::Runner.new(sub_run_context).converge
     ensure
-      if sub_run_context.resource_collection.any?(&:updated?)
-        new_resource.updated_by_last_action(true)
-      end
+      new_resource.updated_by_last_action(true) if sub_run_context.resource_collection.any?(&:updated?)
     end
   end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'brian.bianco@gmail.com'
 license          'Apache-2.0'
 description      'Installs/Configures redis'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.7.2'
+version          '3.0.0'
 
 %w(
   amazon
@@ -21,7 +21,7 @@ end
 
 source_url 'https://github.com/brianbianco/redisio'	if respond_to?(:source_url)
 issues_url 'https://github.com/brianbianco/redisio/issues' if respond_to?(:issues_url)
-chef_version '>= 11' if respond_to?(:chef_version)
+chef_version '>= 13.3' if respond_to?(:chef_version)
 
 recipe 'redisio::default', 'This recipe is used to install the prequisites for building and installing redis, as well as provides the LWRPs'
 recipe 'redisio::install', 'This recipe is used to install redis'

--- a/metadata.rb
+++ b/metadata.rb
@@ -21,7 +21,7 @@ end
 
 source_url 'https://github.com/brianbianco/redisio'	if respond_to?(:source_url)
 issues_url 'https://github.com/brianbianco/redisio/issues' if respond_to?(:issues_url)
-chef_version '>= 13.3' if respond_to?(:chef_version)
+chef_version '>= 13.0' if respond_to?(:chef_version)
 
 recipe 'redisio::default', 'This recipe is used to install the prequisites for building and installing redis, as well as provides the LWRPs'
 recipe 'redisio::install', 'This recipe is used to install redis'

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -50,9 +50,8 @@ def configure
     # Merge in the default maxmemory
     node_memory_kb = node['memory']['total']
     # On BSD platforms Ohai reports total memory as a Fixnum
-    if node_memory_kb.is_a? String
-      node_memory_kb = node_memory_kb.sub('kB', '').to_i
-    end
+
+    node_memory_kb = node_memory_kb.sub('kB', '').to_i if node_memory_kb.is_a?(String)
 
     # Here we determine what the logfile is.  It has these possible states
     #
@@ -212,7 +211,7 @@ def configure
 
       # Load password for use with requirepass from data bag if needed
       if current['data_bag_name'] && current['data_bag_item'] && current['data_bag_key']
-        bag = Chef::EncryptedDataBagItem.load(current['data_bag_name'], current['data_bag_item'])
+        bag = data_bag_item(current['data_bag_name'], current['data_bag_item'])
         current['requirepass'] = bag[current['data_bag_key']]
         current['masterauth'] = bag[current['data_bag_key']]
       end
@@ -402,7 +401,8 @@ def configure
         end
       end
     end
-  end # servers each loop
+  end
+  # servers each loop
 end
 
 def load_current_resource

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -132,7 +132,7 @@ def configure
 
       # Load password for use with requirepass from data bag if needed
       if current['data_bag_name'] && current['data_bag_item'] && current['data_bag_key']
-        bag = Chef::EncryptedDataBagItem.load(current['data_bag_name'], current['data_bag_item'])
+        bag = data_bag_item(current['data_bag_name'], current['data_bag_item'])
         masters.each do |master|
           master['auth_pass'] = bag[current['data_bag_key']]
         end
@@ -243,7 +243,8 @@ def configure
         only_if { node['redisio']['job_control'] == 'rcinit' }
       end
     end
-  end # servers each loop
+  end
+  # servers each loop
 end
 
 def redis_exists?

--- a/test/unit/spec/sentinel_spec.rb
+++ b/test/unit/spec/sentinel_spec.rb
@@ -1,5 +1,3 @@
-# Encoding: utf-8
-
 require_relative 'spec_helper'
 
 # the runlist came from test-kitchen's default suite

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# Encoding: utf-8
-
 require 'rspec/expectations'
 require 'chefspec'
 require 'chefspec/berkshelf'


### PR DESCRIPTION
This is a breaking change and should be a major version release as we drop support for `chef` versions less than `13.3`.

There is more cleanup work to do but this is a good first step.

Signed-off-by: Ben Abrams <me@benabrams.it>