### PR TITLE
Add protected-mode option in sentinel config file

### DIFF
--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -44,6 +44,7 @@ default['redisio']['sentinel_defaults'] = {
   'announce-port'           => nil,
   'notification-script'     => nil,
   'client-reconfig-script'  => nil,
+  'protected_mode'          => nil,
 }
 
 # Manage Sentinel Config File

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -170,7 +170,8 @@ def configure
           announce_ip:            current['announce-ip'],
           announce_port:          current['announce-port'],
           notification_script:    current['notification-script'],
-          client_reconfig_script: current['client-reconfig-script']
+          client_reconfig_script: current['client-reconfig-script'],
+          protected_mode:         current['protected_mode']
         )
         not_if { ::File.exist?("#{current['configdir']}/#{sentinel_name}.conf.breadcrumb") }
       end

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -11,10 +11,27 @@ syslog-ident redis-<%= @name %>
 syslog-facility <%= @syslogfacility %>
 <%= "logfile #{@logfile}" unless @logfile.nil? %>
 
-# bind sentinel IP
+# *** IMPORTANT ***
+#
+# By default Sentinel will not be reachable from interfaces different than
+# localhost, either use the 'bind' directive to bind to a list of network
+# interfaces, or disable protected mode with "protected-mode no" by
+# adding it to this configuration file.
+#
+# Before doing that MAKE SURE the instance is protected from the outside
+# world via firewalling or other means.
+#
+# For example you may use one of the following:
+#
+# bind 127.0.0.1 192.168.1.1
+#
+# protected-mode no
 <% if @sentinel_bind %>
 bind <%=@sentinel_bind%>
 <% end %>
+
+<%= "protected-mode #{@protected_mode}" unless @protected_mode.nil? %>
+
 # port <sentinel-port>
 # The port that this sentinel instance will run on
 port <%=@sentinel_port%>


### PR DESCRIPTION
### Description

Option to enable/disable protected-mode option at the sentinel level and the configs a written are written to sentinel.conf
References: http://download.redis.io/redis-stable/sentinel.conf

### Issues Resolved
https://github.com/sous-chefs/redisio/issues/387

### Contribution Checklist

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
