### PR TITLE
Adding protected_mode to default attributes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Available options and their defaults
 'rdbchecksum'             => 'yes',
 'dbfilename'              => nil,
 'slaveof'                 => nil,
+'protected_mode'          => nil,
 'masterauth'              => nil,
 'slaveservestaledata'     => 'yes',
 'slavereadonly'           => 'yes',


### PR DESCRIPTION
This pull request adds the protected_mode to the default attributes list in the README. Saw it in the codebase, but couldn't find it in the README when working with the project. I hope this fix helps!

