### PR TITLE
Add protected mode to sentinel configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Add protected mode to sentinel configuration file
+
 ## 6.0.0 - *2021-09-09*
 
 - Set unified_mode true for Chef 17+ support

--- a/README.md
+++ b/README.md
@@ -413,7 +413,8 @@ The sentinel recipe's use their own attribute file.
 'logfile'                 => nil,
 'syslogenabled'           => 'yes',
 'syslogfacility'          => 'local0',
-'quorum_count'            => 2
+'quorum_count'            => 2,
+'protected-mode'          => nil
 ```
 
 * `redisio['redisio']['sentinel']['manage_config']` - Should the cookbook manage the redis and redis sentinel config files.  This is best set to false when using redis_sentinel as it will write state into both configuration files.

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ The sentinel recipe's use their own attribute file.
 'syslogenabled'           => 'yes',
 'syslogfacility'          => 'local0',
 'quorum_count'            => 2,
-'protected-mode'          => nil
+'protected-mode'          => nil,
 ```
 
 * `redisio['redisio']['sentinel']['manage_config']` - Should the cookbook manage the redis and redis sentinel config files.  This is best set to false when using redis_sentinel as it will write state into both configuration files.

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -26,6 +26,7 @@ default['redisio']['sentinel_defaults'] = {
   'announce-port'           => nil,
   'notification-script'     => nil,
   'client-reconfig-script'  => nil,
+  'protected_mode'          => nil,
 }
 
 # Manage Sentinel Config File

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -81,13 +81,13 @@ suites:
             sentinel_bind: 0.0.0.0
             sentinel_port: 26379
             masters:
-          -
-            name: 'sentinel6379'
-            master_name: 'master6379'
-            master_ip: '127.0.0.1'
-            master_port: 6379
-          -
-            name: 'sentinel6380'
-            master_name: 'master6380'
-            master_ip: '127.0.0.1'
-            master_port: 6380
+              -
+                name: 'sentinel6379'
+                master_name: 'master6379'
+                master_ip: '127.0.0.1'
+                master_port: 6379
+              -
+                name: 'sentinel6380'
+                master_name: 'master6380'
+                master_ip: '127.0.0.1'
+                master_port: 6380

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -151,7 +151,8 @@ def configure
           announce_ip:            current['announce-ip'],
           announce_port:          current['announce-port'],
           notification_script:    current['notification-script'],
-          client_reconfig_script: current['client-reconfig-script']
+          client_reconfig_script: current['client-reconfig-script'],
+          protected_mode:         current['protected_mode']
         )
         not_if { ::File.exist?("#{current['configdir']}/#{sentinel_name}.conf.breadcrumb") }
       end

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -30,7 +30,9 @@ syslog-facility <%= @syslogfacility %>
 bind <%=@sentinel_bind%>
 <% end %>
 
-<%= "protected-mode #{@protected_mode}" unless @protected_mode.nil? %>
+ <% if @protected_mode %>
+<%= "protected-mode #{@protected_mode}" %>
+<% end %>
 
 # port <sentinel-port>
 # The port that this sentinel instance will run on

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -11,21 +11,6 @@ syslog-ident redis-<%= @name %>
 syslog-facility <%= @syslogfacility %>
 <%= "logfile #{@logfile}" unless @logfile.nil? %>
 
-# *** IMPORTANT ***
-#
-# By default Sentinel will not be reachable from interfaces different than
-# localhost, either use the 'bind' directive to bind to a list of network
-# interfaces, or disable protected mode with "protected-mode no" by
-# adding it to this configuration file.
-#
-# Before doing that MAKE SURE the instance is protected from the outside
-# world via firewalling or other means.
-#
-# For example you may use one of the following:
-#
-# bind 127.0.0.1 192.168.1.1
-#
-# protected-mode no
 <% if @sentinel_bind %>
 bind <%=@sentinel_bind%>
 <% end %>

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -11,10 +11,27 @@ syslog-ident redis-<%= @name %>
 syslog-facility <%= @syslogfacility %>
 <%= "logfile #{@logfile}" unless @logfile.nil? %>
 
-# bind sentinel IP
+# *** IMPORTANT ***
+#
+# By default Sentinel will not be reachable from interfaces different than
+# localhost, either use the 'bind' directive to bind to a list of network
+# interfaces, or disable protected mode with "protected-mode no" by
+# adding it to this configuration file.
+#
+# Before doing that MAKE SURE the instance is protected from the outside
+# world via firewalling or other means.
+#
+# For example you may use one of the following:
+#
+# bind 127.0.0.1 192.168.1.1
+#
+# protected-mode no
 <% if @sentinel_bind %>
 bind <%=@sentinel_bind%>
 <% end %>
+
+<%= "protected-mode #{@protected_mode}" unless @protected_mode.nil? %>
+
 # port <sentinel-port>
 # The port that this sentinel instance will run on
 port <%=@sentinel_port%>


### PR DESCRIPTION
# Description

This would allow users to configure protected mode option in sentinel configuration file.
https://github.com/antirez/redis/blob/5.0.5/sentinel.conf#L17

## Issues Resolved

https://github.com/sous-chefs/redisio/issues/387

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
