### PR TITLE
Make daemenize option configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Minimum Chef is now 14
 - Removed tests for Debian 8
 - Added support for chef 15
+- Allow to overwrite daemonize property with systemd
 
 ## 3.0.0 (2018-11-27)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -78,7 +78,7 @@ default['redisio']['job_control'] = if node['init_package'] == 'systemd'
                                     else
                                       'initd'
                                     end
-
+default['redisio']['daemonize'] = %w(initd rcinit).include?(default['redisio']['job_control'])
 # Init.d script related options
 default['redisio']['init.d']['required_start'] = []
 default['redisio']['init.d']['required_stop'] = []

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -227,6 +227,7 @@ def configure
           piddir: piddir,
           name: server_name,
           job_control: node['redisio']['job_control'],
+          daemonize: node['redisio']['daemonize'],
           port: current['port'],
           tcpbacklog: current['tcpbacklog'],
           address: current['address'],
@@ -393,7 +394,8 @@ def configure
             bin_path: bin_path,
             user: current['user'],
             group: current['group'],
-            limit_nofile: descriptors
+            limit_nofile: descriptors,
+            daemonize: node['redisio']['daemonize']
           )
           notifies :run, "execute[#{reload_name}]", :immediately
         end

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -227,7 +227,7 @@ def configure
           piddir: piddir,
           name: server_name,
           job_control: node['redisio']['job_control'],
-          daemonize: node['redisio']['daemonize'],
+          daemonize: current['daemonize'],
           port: current['port'],
           tcpbacklog: current['tcpbacklog'],
           address: current['address'],
@@ -395,7 +395,7 @@ def configure
             user: current['user'],
             group: current['group'],
             limit_nofile: descriptors,
-            daemonize: node['redisio']['daemonize']
+            daemonize: current['daemonize']
           )
           notifies :run, "execute[#{reload_name}]", :immediately
         end

--- a/recipes/sentinel.rb
+++ b/recipes/sentinel.rb
@@ -57,7 +57,8 @@ template '/lib/systemd/system/redis-sentinel@.service' do
   source 'redis-sentinel@.service'
   variables(
     bin_path: bin_path,
-    limit_nofile: redis['default_settings']['maxclients'] + 32
+    limit_nofile: redis['default_settings']['maxclients'] + 32,
+    daemonize: node['redisio']['daemonize']
   )
   only_if { node['redisio']['job_control'] == 'systemd' }
 end

--- a/templates/default/redis-sentinel@.service
+++ b/templates/default/redis-sentinel@.service
@@ -3,7 +3,7 @@ Description=Redis persistent key-value database
 After=network.target
 
 [Service]
-ExecStart=<%= @bin_path %>/redis-server /etc/redis/sentinel_%i.conf --sentinel --daemonize no
+ExecStart=<%= @bin_path %>/redis-server /etc/redis/sentinel_%i.conf --sentinel --daemonize <%= @daemonize %>
 User=redis
 Group=redis
 LimitNOFILE=<%= @limit_nofile %>

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -14,7 +14,7 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-<% if @job_control == 'initd' || @job_control == 'rcinit' %>
+<% if @daemonize %>
 daemonize yes
 <% end %>
 

--- a/templates/default/redis@.service.erb
+++ b/templates/default/redis@.service.erb
@@ -3,7 +3,7 @@ Description=Redis (%i) persistent key-value database
 After=network.target
 
 [Service]
-ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize no
+ExecStart=<%= @bin_path %>/redis-server /etc/redis/%i.conf --daemonize <%= @daemonize %>
 User=<%= @user %>
 Group=<%= @group %>
 LimitNOFILE=<%= @limit_nofile %>

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -1,7 +1,7 @@
 # Example sentinel.conf
 
 # redisio Cookbook additions
-<% if @job_control == 'initd' || @job_control == 'rcinit' %>
+<% if @daemonize %>
 daemonize yes
 <% end %>
 pidfile <%= @piddir %>/sentinel_<%=@name%>.pid


### PR DESCRIPTION
# Description
I want to have an explicit `daemonize` configuration property so I can control the setting explicitly. I rather have systemd manage redis instead of redis managing itself. This also allows to write a pid file and allow to have other processes act with it

## Issues Resolved

None really except my own

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
