### PR TITLE
Update to use selinux_policy >= 2.2.0 which includes selinux_policy_install

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,4 +22,4 @@ chef_version      '>= 14.0'
 end
 
 depends 'ulimit', '>= 0.1.2'
-depends 'selinux_policy'
+depends 'selinux_policy', '>= 2.2.0'


### PR DESCRIPTION
As stated in #393, this cookbook requires at least version 2.2.0 and above of
the selinux_policy cookbook. This should resolve #393.

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
