### PR TITLE
Properly version check when needed in redis.conf template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # redisio
 
+## 4.1.1 (2020-08-14)
+
+- Properly perform version check when needed in redis.conf template 
+
 ## 4.1.0 (2020-05-05)
 
 - Simplify platform check logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # redisio
 
-## 4.1.1 (2020-08-14)
+## Unreleased
 
 - Properly perform version check when needed in redis.conf template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 4.1.1 (2020-08-14)
 
-- Properly perform version check when needed in redis.conf template 
+- Properly perform version check when needed in redis.conf template
 
 ## 4.1.0 (2020-05-05)
 

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -823,7 +823,7 @@ vm-pages 134217728
 vm-max-threads 4
 <% end %>
 
-<% if @version[:major].to_i == 2 && @version[:minor].to_i >= 8 || @version[:major].to_i == 3 %>
+<% if @version[:major].to_i == 2 && @version[:minor].to_i >= 8 || @version[:major].to_i >= 3 %>
 <% ######## Redis 2.8 and higher ######## %>
 ############################# Event notification ##############################
 
@@ -882,7 +882,7 @@ notify-keyspace-events "<%= @notifykeyspaceevents %>"
 # to save a lot of space. The special representation is only used when
 # you are under the following limits:
 
-<% if @version[:major].to_i == 2 && @version[:minor].to_i >= 6 || @version[:major].to_i == 3 %>
+<% if @version[:major].to_i == 2 && @version[:minor].to_i >= 6 || @version[:major].to_i >= 3 %>
 <% ######## Redis 2.6 and higher ######## %>
 hash-max-ziplist-entries <%= @hashmaxziplistentries %>
 hash-max-ziplist-value <%= @hashmaxziplistvalue %>


### PR DESCRIPTION
# Description

This change will properly run blocks in the redis.conf.erb template file when checking for redis version "X and higher"

## Issues Resolved

https://github.com/sous-chefs/redisio/issues/427

## Check List

- [ x ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
