### PR TITLE
Config/permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # redisio
 
+## Unrealeased
+
+- New server option 'permissions' to override default (0644) unix permissions on config file
+
 ## 4.1.2 (2020-09-11)
 
 - Pull the disable_os_default recipe from the default one

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Available options and their defaults
 ```config
 'user'                    => 'redis' - the user to own the redis datadir, redis will also run under this user
 'group'                   => 'redis' - the group to own the redis datadir
+'permissions'             => '0644' - the unix permissions applied to the server config file
 'homedir'                 => Home directory of the user. Varies on distribution, check attributes file
 'shell'                   => Users shell. Varies on distribution, check attributes file
 'systemuser'              => true - Sets up the instances user as a system user

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,6 +87,7 @@ default['redisio']['init.d']['required_stop'] = []
 default['redisio']['default_settings'] = {
   'user'                       => 'redis',
   'group'                      => 'redis',
+  'permissions'                => '0644',
   'homedir'                    => homedir,
   'shell'                      => shell,
   'systemuser'                 => true,

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -34,6 +34,7 @@ suites:
         servers:
           - port: 6379
           - port: 16379
+            permissions: '0640'
             name: 'savetest'
             save: "a\nb\nc"
 

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -220,7 +220,7 @@ def configure
         cookbook node['redisio']['redis_config']['template_cookbook']
         owner current['user']
         group current['group']
-        mode '0644'
+        mode current['permissions']
         action :create
         variables(
           version:                    version_hash,

--- a/test/integration/default/serverspec/redisio_spec.rb
+++ b/test/integration/default/serverspec/redisio_spec.rb
@@ -8,6 +8,7 @@ end
 
 describe file("#{prefix}/etc/redis/savetest.conf") do
   it { should be_file }
+  its('mode') { should cmp '0640' }
 
   ['save a', 'save b', 'save c'].each do |m|
     its(:content) { should match(m) }


### PR DESCRIPTION
# Description

Allow to override default permissions (0644) on server config files

## Issues Resolved

Needed when an auth is setup to prevent all to read the password from config files

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
