### PR TITLE
Fix disable recipe service naming for systemd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # redisio
 
+## Unreleased
+
+- Fix disable recipe service naming for systemd
+
 ## 4.2.0 (2020-09-14)
 
 - New server option 'permissions' to override default (0644) unix permissions on config file

--- a/recipes/disable.rb
+++ b/recipes/disable.rb
@@ -22,7 +22,12 @@ redis = node['redisio']
 
 redis['servers'].each do |current_server|
   server_name = current_server['name'] || current_server['port']
-  resource = resources("service[redis#{server_name}]")
+  resource_name = if node['redisio']['job_control'] == 'systemd'
+                    "service[redis@#{server_name}]"
+                  else
+                    "service[redis#{server_name}]"
+                  end
+  resource = resources(resource_name)
   resource.action Array(resource.action)
   resource.action << :stop
   resource.action << :disable


### PR DESCRIPTION
# Description

71469215 introduced systemd support, which uses a slightly different
service naming convention (ie. redis@6379 vs redis6379), and updated the
enable recipe to conditionally use the right service name, however the
disable recipe wasn't updated to match, thus leading to using the wrong
service name when using systemd, leading to an unknown service.

I didn't see any tests around the disable recipe, so I wasn't sure on where to start to add new ones.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
