### PR TITLE
Fixes configdir permissions (Closes #450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Fixes configdir permissions preventing Sentinel to update the config file
+
 ## 6.1.1 - *2022-02-03*
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -91,8 +91,8 @@ def configure
       # Create the redis configuration directory
       directory current['configdir'] do
         owner 'root'
-        group platform_family?('freebsd') ? 'wheel' : 'root'
-        mode '0755'
+        group platform_family?('freebsd') ? 'wheel' : 'redis'
+        mode '0775'
         recursive true
         action :create
       end


### PR DESCRIPTION
# Description

It changes the configdir group to `redis` instead of `root` and the write permission to that group.

## Issues Resolved
#450 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
