### PR TITLE
Remove references to selinux_policy cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Remove references to selinux_policy cookbook
+
 ## 6.1.2 - *2022-02-03*
 
 - Fixes configdir permissions preventing Sentinel to update the config file

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -126,19 +126,19 @@ def configure
       extend Chef::Util::Selinux
 
       if selinux_enabled?
-        selinux_policy_install 'install'
+        selinux_install 'install'
 
-        selinux_policy_fcontext "#{current['configdir']}(/.*)?" do
+        selinux_fcontext "#{current['configdir']}(/.*)?" do
           secontext 'redis_conf_t'
         end
-        selinux_policy_fcontext "#{current['datadir']}(/.*)?" do
+        selinux_fcontext "#{current['datadir']}(/.*)?" do
           secontext 'redis_var_lib_t'
         end
-        selinux_policy_fcontext "#{piddir}(/.*)?" do
+        selinux_fcontext "#{piddir}(/.*)?" do
           secontext 'redis_var_run_t'
         end
         if log_directory
-          selinux_policy_fcontext "#{log_directory}(/.*)?" do
+          selinux_fcontext "#{log_directory}(/.*)?" do
             secontext 'redis_log_t'
           end
         end


### PR DESCRIPTION


# Description

providers/configure.rb was still calling resources from the selinux_policy cookbook, which was deprecated in 6.0.0 causing cinc-client runs to die with NoMethodError

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
