### PR TITLE
Add maxclients option to sentinel config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Add `maxclients` option to sentinel configuration file.
+
 ## 6.4.4 - *2023-09-28*
 
 ## 6.4.3 - *2023-09-04*

--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ The sentinel recipe's use their own attribute file.
 'syslogfacility'          => 'local0',
 'quorum_count'            => 2,
 'protected-mode'          => nil,
+'maxclients'              => 10000, 
 ```
 
 * `redisio['redisio']['sentinel']['manage_config']` - Should the cookbook manage the redis and redis sentinel config files.  This is best set to false when using redis_sentinel as it will write state into both configuration files.

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -27,6 +27,7 @@ default['redisio']['sentinel_defaults'] = {
   'notification-script'     => nil,
   'client-reconfig-script'  => nil,
   'protected_mode'          => nil,
+  'maxclients'              => 10000,
 }
 
 # Manage Sentinel Config File

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -146,7 +146,8 @@ action :run do
         announce_port:          current['announce-port'],
         notification_script:    current['notification-script'],
         client_reconfig_script: current['client-reconfig-script'],
-        protected_mode:         current['protected_mode']
+        protected_mode:         current['protected_mode'],
+        maxclients:             current['maxclients']
       )
       not_if { ::File.exist?("#{current['configdir']}/#{sentinel_name}.conf.breadcrumb") }
     end

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -9,6 +9,7 @@ loglevel <%=@loglevel%>
 syslog-enabled <%= @syslogenabled %>
 syslog-ident redis-<%= @name %>
 syslog-facility <%= @syslogfacility %>
+maxclients <%= @maxclients %>
 <%= "logfile #{@logfile}" unless @logfile.nil? %>
 
 <% if @sentinel_bind %>


### PR DESCRIPTION
# Description

Adding `maxclients` option to Sentinel configuration file.

## Issues Resolved

Currently there's no way to set `maxclients` for Sentinel instances.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
