### PR TITLE
add option to set aclfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Add `aclfile` option to redis configuration file.
+
 ## 6.5.0 - *2023-10-31*
 
 - Add `maxclients` option to sentinel configuration file.

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Available options and their defaults
 'clusterconfigfile'          => nil, # Defaults to redis instance name inside of template if cluster is enabled.
 'clusternodetimeout'         => 5000,
 'includes'                   => nil,
+'aclfile'                    => nil, # Requires redis 6+
 'breadcrumb'                 => true # Defaults to create breadcrumb lock-file.
 ```
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -145,6 +145,7 @@ default['redisio']['default_settings'] = {
   'clusterconfigfile'          => nil, # Defaults to redis instance name inside of template if cluster is enabled.
   'clusternodetimeout'         => 5000,
   'includes'                   => nil,
+  'aclfile'                    => nil,
   'data_bag_name'              => nil,
   'data_bag_item'              => nil,
   'data_bag_key'               => nil,

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -263,6 +263,7 @@ action :run do
         clusterconfigfile:          current['clusterconfigfile'],
         clusternodetimeout:         current['clusternodetimeout'],
         includes:                   current['includes'],
+        aclfile:                    current['aclfile'],
         minslavestowrite:           current['minslavestowrite'],
         minslavesmaxlag:            current['minslavesmaxlag'],
         repldisklesssync:           current['repldisklesssync'],

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -1023,6 +1023,22 @@ cluster-config-file <%= @clusterconfigfile || "nodes-#{@name}.conf" %>
 cluster-node-timeout <%= @clusternodetimeout %>
 <%end%>
 
+<% if @version[:major].to_i >= 6 %>
+# Using an external ACL file
+#
+# Instead of configuring users here in this file, it is possible to use
+# a stand-alone file just listing users. The two methods cannot be mixed:
+# if you configure users here and at the same time you activate the external
+# ACL file, the server will refuse to start.
+#
+# The format of the external ACL user file is exactly the same as the
+# format that is used inside redis.conf to describe users.
+#
+  <% unless @aclfile.nil? %>
+aclfile <%= @aclfile %>
+  <% end %>
+<% end %>
+
 ################################## INCLUDES ###################################
 
 # Include one or more other config files here.  This is useful if you


### PR DESCRIPTION
# Description

Adding `aclfile` option to Redis configuration file.

## Issues Resolved

Enables configuring external ACL file for Redis v6+

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
