### PR TITLE
Sentinel: add option to set aclfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Add `aclfile` option to sentinel configuration file.
+
 ## 6.6.0 - *2023-11-11*
 
 - Add `aclfile` option to redis configuration file.

--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ The sentinel recipe's use their own attribute file.
 'syslogfacility'          => 'local0',
 'quorum_count'            => 2,
 'protected-mode'          => nil,
-'maxclients'              => 10000, 
+'maxclients'              => 10000,
+'aclfile'                 => nil, # Requires redis 6+
 ```
 
 * `redisio['redisio']['sentinel']['manage_config']` - Should the cookbook manage the redis and redis sentinel config files.  This is best set to false when using redis_sentinel as it will write state into both configuration files.

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -28,6 +28,7 @@ default['redisio']['sentinel_defaults'] = {
   'client-reconfig-script'  => nil,
   'protected_mode'          => nil,
   'maxclients'              => 10000,
+  'aclfile'                 => nil,
 }
 
 # Manage Sentinel Config File

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -147,7 +147,8 @@ action :run do
         notification_script:    current['notification-script'],
         client_reconfig_script: current['client-reconfig-script'],
         protected_mode:         current['protected_mode'],
-        maxclients:             current['maxclients']
+        maxclients:             current['maxclients'],
+        aclfile:                current['aclfile']
       )
       not_if { ::File.exist?("#{current['configdir']}/#{sentinel_name}.conf.breadcrumb") }
     end

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -82,6 +82,24 @@ port <%=@sentinel_port%>
 <% calc_name = String(current['master_name'] || @name || 'master_name') %>
 <%= "sentinel auth-pass #{calc_name} #{current['auth_pass']}" unless current['auth_pass'].nil? %>
 <% end %>
+
+<% if @version[:major].to_i >= 6 %>
+# Using an external ACL file
+#
+# Instead of configuring users here in this file, it is possible to use
+# a stand-alone file just listing users. The two methods cannot be mixed:
+# if you configure users here and at the same time you activate the external
+# ACL file, the server will refuse to start.
+#
+# The format of the external ACL user file is exactly the same as the
+# format that is used inside redis.conf to describe users.
+#
+# aclfile /etc/redis/sentinel-users.acl
+  <% unless @aclfile.nil? %>
+aclfile <%= @aclfile %>
+  <% end %>
+<% end %>
+
 # sentinel down-after-milliseconds <master-name> <milliseconds>
 #
 # Number of milliseconds the master (or any attached slave or sentinel) should


### PR DESCRIPTION
# Description

Adding aclfile option to Sentinel configuration file.

## Issues Resolved

Enables configuring external ACL file for Redis Sentinel v6+

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
