### PR TITLE
Add includes option to sentinel config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Add `includes` option to sentinel configuration file.
+
 ## 6.7.0 - *2024-01-04*
 
 - Add `aclfile` option to sentinel configuration file.

--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ The sentinel recipe's use their own attribute file.
 'protected-mode'          => nil,
 'maxclients'              => 10000,
 'aclfile'                 => nil, # Requires redis 6+
+'includes'                => nil,
 ```
 
 * `redisio['redisio']['sentinel']['manage_config']` - Should the cookbook manage the redis and redis sentinel config files.  This is best set to false when using redis_sentinel as it will write state into both configuration files.

--- a/attributes/redis_sentinel.rb
+++ b/attributes/redis_sentinel.rb
@@ -29,6 +29,7 @@ default['redisio']['sentinel_defaults'] = {
   'protected_mode'          => nil,
   'maxclients'              => 10000,
   'aclfile'                 => nil,
+  'includes'                => nil,
 }
 
 # Manage Sentinel Config File

--- a/providers/sentinel.rb
+++ b/providers/sentinel.rb
@@ -148,7 +148,8 @@ action :run do
         client_reconfig_script: current['client-reconfig-script'],
         protected_mode:         current['protected_mode'],
         maxclients:             current['maxclients'],
-        aclfile:                current['aclfile']
+        aclfile:                current['aclfile'],
+        includes:               current['includes']
       )
       not_if { ::File.exist?("#{current['configdir']}/#{sentinel_name}.conf.breadcrumb") }
     end

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -220,3 +220,18 @@ aclfile <%= @aclfile %>
 # sentinel client-reconfig-script mymaster /var/redis/reconfig.sh
 <%= "sentinel client-reconfig-script #{@name} #{@client_reconfig_script}" unless @client_reconfig_script.nil? %>
 <% end %>
+
+################################## INCLUDES ###################################
+
+# Include one or more other config files here.  This is useful if you
+# have a standard template that goes to all redis server but also need
+# to customize a few per-server settings.  Include files can include
+# other files, so use this wisely.
+#
+# include /path/to/local.conf
+# include /path/to/other.conf
+<% unless @includes.nil? %>
+  <% @includes.each do |include_option| %>
+    <%= "include #{include_option}" %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
# Description

Add `includes` option to Sentinel configuration file.

## Issues Resolved

Currently, there's no way to include custom config files into Sentinel config. 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
