### PR TITLE
Add cluster-port option to redis config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
+- Add option to specify `cluster-port`
+
 ## 7.1.1 - *2024-04-21*
 
 - Fix default `tls*` attribute names

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Available options and their defaults
 'clusterenabled'             => 'no',
 'clusterconfigfile'          => nil, # Defaults to redis instance name inside of template if cluster is enabled.
 'clusternodetimeout'         => 5000,
+'clusterport'                => nil,
 'includes'                   => nil,
 'aclfile'                    => nil, # Requires redis 6+
 'breadcrumb'                 => true # Defaults to create breadcrumb lock-file.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -142,6 +142,7 @@ default['redisio']['default_settings'] = {
   'clusterenabled'             => 'no',
   'clusterconfigfile'          => nil, # Defaults to redis instance name inside of template if cluster is enabled.
   'clusternodetimeout'         => 5000,
+  'clusterport'                => nil,
   'includes'                   => nil,
   'aclfile'                    => nil,
   'data_bag_name'              => nil,

--- a/providers/configure.rb
+++ b/providers/configure.rb
@@ -260,6 +260,7 @@ action :run do
         clusterenabled:             current['clusterenabled'],
         clusterconfigfile:          current['clusterconfigfile'],
         clusternodetimeout:         current['clusternodetimeout'],
+        clusterport:                current['clusterport'],
         includes:                   current['includes'],
         aclfile:                    current['aclfile'],
         minreplicastowrite:         current['minreplicastowrite'],

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -1033,6 +1033,7 @@ aof-rewrite-incremental-fsync <%= @aofrewriteincrementalfsync %>
 cluster-enabled yes
 cluster-config-file <%= @clusterconfigfile || "nodes-#{@name}.conf" %>
 cluster-node-timeout <%= @clusternodetimeout %>
+<%= "cluster-port #{@clusterport}" unless @clusterport.nil? %>
 <%end%>
 
 <% if @version[:major].to_i >= 6 %>


### PR DESCRIPTION
# Description

Currently, there's no way to specify custom `cluster-port` value. Adding this option to the configuration file.

## Issues Resolved

No related issues.

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
