### PR TITLE
Add ability to enable TLS support when installing from source

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,7 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :integration do
+  cookbook 'test', path: './test/cookbooks/test'
   cookbook 'yum-epel'
   cookbook 'yum-remi-chef'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This file is used to list changes made in each version of the redisio cookbook.
 
 ## Unreleased
 
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
+- Add ability to enable TLS support when installing from source
 
 ## 7.2.4 - *2025-09-04*
 

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Configuration options, each option corresponds to the same-named configuration o
 * `redisio['base_piddir']` - This is the directory that redis pidfile directories and pidfiles will be placed in.  Since redis can run as non root, it needs to have proper
                            permissions to the directory to create its pid.  Since each instance can run as a different user, these directories will all be nested inside this base one.
 * `redisio['bypass_setup']` - This attribute allows users to prevent the default recipe from calling the install and configure recipes.
+* `redisio['enable_tls']` - When building from source, enable TLS support.
 * `redisio['job_control']` - This deteremines what job control type will be used.  Currently supports 'initd' or 'upstart' options.  Defaults to 'initd'.
 
 Default settings is a hash of default settings to be applied to to ALL instances.  These can be overridden for each individual server in the servers attribute.  If you are going to set logfile to a specific file, make sure to set syslog-enabled to no.
@@ -477,6 +478,7 @@ Attribute Parameters
 * `artifact_type` - the file extension of the package
 * `base_name` - the name of the package minus the extension and version number
 * `safe_install` - a true or false value which determines if a version of redis will be installed if one already exists, defaults to true
+* `enable_tls` - enable TLS support when building from source
 
 This resource expects the following naming conventions:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['redisio']['safe_install'] = true
 default['redisio']['package_install'] = default_package_install
 default['redisio']['package_name'] =  package_name
 default['redisio']['bypass_setup'] = false
+default['redisio']['enable_tls'] = false
 
 # Tarball and download related defaults
 default['redisio']['mirror'] = 'http://download.redis.io/releases/'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -41,6 +41,23 @@ suites:
             save: "3600 1\n300 100\n60 10000"
             logfile: '/var/log/redis/redis-16379.log'
 
+  - name: default_tls
+    run_list:
+      - recipe[redisio::default]
+      - recipe[test::default_tls]
+      - recipe[redisio::enable]
+    attributes:
+      redisio:
+        version: "<%= ENV['REDIS_VERSION'] || '6.2.3' %>"
+        enable_tls: true
+        servers:
+          - name: '6379-tls'
+            port: 0
+            tlsport: 6379
+            tlscertfile: '/etc/redis/ssl/redis.crt'
+            tlskeyfile: '/etc/redis/ssl/redis.key'
+            tlscacertfile: '/etc/redis/ssl/redis-ca.crt'
+
   - name: sentinel
     run_list:
       - recipe[redisio::default]

--- a/providers/install.rb
+++ b/providers/install.rb
@@ -46,7 +46,12 @@ def unpack
 end
 
 def build
-  execute "cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make clean && make"
+  build_tls = if new_resource.enable_tls
+                'BUILD_TLS=yes'
+              else
+                'BUILD_TLS=no'
+              end
+  execute "cd #{new_resource.download_dir}/#{new_resource.base_name}#{new_resource.version} && make clean && make #{build_tls}"
 end
 
 def install

--- a/recipes/_install_prereqs.rb
+++ b/recipes/_install_prereqs.rb
@@ -1,11 +1,11 @@
 packages_to_install = case node['platform_family']
                       when 'debian'
                         %w(
-                          tar
+                          libssl-dev tar
                         )
                       when 'rhel', 'fedora'
                         %w(
-                          tar
+                          openssl-devel tar
                         )
                       else
                         %w()

--- a/recipes/enable.rb
+++ b/recipes/enable.rb
@@ -3,11 +3,11 @@ redis = node['redisio']
 redis['servers'].each do |current_server|
   server_name = current_server['name'] || current_server['port']
   resource_name = if node['redisio']['job_control'] == 'systemd'
-                    "service[redis@#{server_name}]"
+                    "redis@#{server_name}"
                   else
-                    "service[redis#{server_name}]"
+                    "redis#{server_name}"
                   end
-  resource = resources(resource_name)
-  resource.action Array(resource.action)
-  resource.action.concat [:start, :enable]
+  service resource_name do
+    action [:start, :enable]
+  end
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -16,6 +16,7 @@ else
     download_url location
     safe_install redis['safe_install']
     install_dir redis['install_dir'] if redis['install_dir']
+    enable_tls redis['enable_tls']
   end
 end
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -9,5 +9,6 @@ attribute :download_dir, kind_of: String, default: Chef::Config[:file_cache_path
 attribute :artifact_type, kind_of: String, default: 'tar.gz'
 attribute :base_name, kind_of: String, default: 'redis-'
 attribute :safe_install, kind_of: [TrueClass, FalseClass], default: true
+attribute :enable_tls, kind_of: [TrueClass, FalseClass], default: false
 
 attribute :install_dir, kind_of: String, default: nil

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+name 'test'
+maintainer 'Sous Chefs'
+maintainer_email 'help@sous-chefs.org'
+license 'Apache-2.0'
+description 'Installs/Configures test'
+version '0.1.0'
+
+depends 'redisio'

--- a/test/cookbooks/test/recipes/default_tls.rb
+++ b/test/cookbooks/test/recipes/default_tls.rb
@@ -1,0 +1,48 @@
+directory '/etc/redis/ssl' do
+  owner 'redis'
+  group 'redis'
+  mode '0755'
+  action :create
+end
+
+openssl_x509_certificate '/etc/redis/ssl/redis-ca.crt' do
+  common_name 'redis-ca'
+  expire 365
+  extensions(
+    'keyUsage' => {
+      'values' => %w(
+        keyCertSign
+        keyEncipherment
+        digitalSignature
+        cRLSign),
+      'critical' => true,
+    }
+  )
+  owner 'redis'
+  group 'redis'
+  action :create
+end
+
+openssl_x509_certificate '/etc/redis/ssl/redis.crt' do
+  common_name 'redis'
+  ca_key_file '/etc/redis/ssl/redis-ca.key'
+  ca_cert_file '/etc/redis/ssl/redis-ca.crt'
+  expire 365
+  extensions(
+    'keyUsage' => {
+      'values' => %w(
+        keyEncipherment
+        digitalSignature),
+      'critical' => true,
+    },
+    'extendedKeyUsage' => {
+      'values' => %w(
+        serverAuth
+        clientAuth),
+      'critical' => false,
+    }
+  )
+  owner 'redis'
+  group 'redis'
+  action :create
+end

--- a/test/integration/default_tls/certificate_spec.rb
+++ b/test/integration/default_tls/certificate_spec.rb
@@ -1,0 +1,15 @@
+describe x509_certificate('/etc/redis/ssl/redis.crt') do
+  it { should be_certificate }
+  its('key_length') { should be 2048 }
+  its('validity_in_days') { should be > 30 }
+  its('subject.CN') { should match 'redis' }
+  its('issuer.CN') { should match /redis-ca/ }
+end
+
+describe x509_certificate('/etc/redis/ssl/redis-ca.crt') do
+  it { should be_certificate }
+  its('key_length') { should be 2048 }
+  its('validity_in_days') { should be > 30 }
+  its('subject.CN') { should match 'redis-ca' }
+  its('issuer.CN') { should match /redis-ca/ }
+end

--- a/test/integration/default_tls/redisio_spec.rb
+++ b/test/integration/default_tls/redisio_spec.rb
@@ -1,0 +1,14 @@
+describe service('redis@6379-tls') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe port(6379) do
+  it { should be_listening }
+end
+
+describe command('redis-cli -h localhost -p 6379 --tls --cert /etc/redis/ssl/redis.crt --key /etc/redis/ssl/redis.key --cacert /etc/redis/ssl/redis-ca.crt ping') do
+  its(:stdout) { should match 'PONG' }
+  its('exit_status') { should eq 0 }
+end


### PR DESCRIPTION
# Description

This PR adds an attribute `enable_tls` and a property `enable_tls` to `redisio_install` which allows building/installing from source with TLS support.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
