### PR TITLE
feat: add valkey package support

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[env]
+_.path = "/opt/chef-workstation/bin"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Cookbook Version](https://img.shields.io/cookbook/v/redisio.svg)](https://supermarket.chef.io/cookbooks/redisio)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
-`redisio` is a resource-first Sous Chefs cookbook for installing Redis and managing Redis server and Sentinel instances with systemd.
+`redisio` is a resource-first Sous Chefs cookbook for installing Redis or Valkey and managing server and Sentinel instances with systemd.
 
 ## Supported Platforms
 
@@ -40,6 +40,20 @@ end
 
 redisio_server '6379' do
   package_install true
+end
+```
+
+### Install Valkey from packages and start one instance
+
+```ruby
+redisio_install 'default' do
+  package_install true
+  server_implementation 'valkey'
+end
+
+redisio_server '6379' do
+  package_install true
+  server_implementation 'valkey'
 end
 ```
 

--- a/documentation/redisio_configure.md
+++ b/documentation/redisio_configure.md
@@ -9,10 +9,11 @@ Compatibility wrapper that expands the legacy `default_settings` plus `servers` 
 
 ## Properties
 
-- `version` (`String`, default: `nil`): Redis version override
-- `base_piddir` (`String`, default: `/var/run/redis`): Base pid directory
-- `user` (`String`, default: `redis`): Default user fallback
-- `group` (`String`, default: `redis`): Default group fallback
+- `version` (`String`, default: `nil`): Redis or Valkey version override
+- `server_implementation` (`String`, default: `redis`): Select `redis` or `valkey`
+- `base_piddir` (`String`, default: implementation specific): Base pid directory
+- `user` (`String`, default: implementation specific): Default user fallback
+- `group` (`String`, default: implementation specific): Default group fallback
 - `default_settings` (`Hash`, default: `{}`): Shared settings merged into every server definition
 - `servers` (`Array`, default: `nil`): Server definitions; `nil` creates one default `6379` instance
 - `package_install` (`Boolean`, default: `false`): Package install compatibility hint

--- a/documentation/redisio_install.md
+++ b/documentation/redisio_install.md
@@ -1,6 +1,6 @@
 # redisio_install
 
-Installs or removes Redis either from distro packages or from source.
+Installs or removes Redis or Valkey either from distro packages or from source.
 
 ## Actions
 
@@ -10,6 +10,7 @@ Installs or removes Redis either from distro packages or from source.
 ## Properties
 
 - `package_install` (`Boolean`, default: `false`): Install from OS packages instead of source
+- `server_implementation` (`String`, default: `redis`): Select `redis` or `valkey`
 - `package_name` (`String`, default: platform specific): Package name override
 - `version` (`String`, default: source installs use `3.2.11`): Redis version to install
 - `download_url` (`String`, default: derived): Tarball URL for source installs
@@ -29,6 +30,15 @@ redisio_install 'default' do
 end
 ```
 
+### Install Valkey from packages
+
+```ruby
+redisio_install 'default' do
+  package_install true
+  server_implementation 'valkey'
+end
+```
+
 ### Install a specific source release
 
 ```ruby
@@ -36,3 +46,5 @@ redisio_install 'default' do
   version '7.4.8'
 end
 ```
+
+Valkey support in this resource is currently package-only. Source installs still target Redis.

--- a/documentation/redisio_sentinel.md
+++ b/documentation/redisio_sentinel.md
@@ -9,10 +9,11 @@ Compatibility wrapper that expands the legacy `sentinel_defaults` plus `sentinel
 
 ## Properties
 
-- `version` (`String`, default: `nil`): Redis version override
-- `base_piddir` (`String`, default: `/var/run/redis`): Base pid directory
-- `user` (`String`, default: `redis`): Default user fallback
-- `group` (`String`, default: `redis`): Default group fallback
+- `version` (`String`, default: `nil`): Redis or Valkey version override
+- `server_implementation` (`String`, default: `redis`): Select `redis` or `valkey`
+- `base_piddir` (`String`, default: implementation specific): Base pid directory
+- `user` (`String`, default: implementation specific): Default user fallback
+- `group` (`String`, default: implementation specific): Default group fallback
 - `sentinel_defaults` (`Hash`, default: `{}`): Shared settings merged into every sentinel definition
 - `sentinels` (`Array`, default: `nil`): Sentinel definitions; `nil` creates the historic default `mycluster` definition
 - `package_install` (`Boolean`, default: `false`): Package install compatibility hint

--- a/documentation/redisio_sentinel_instance.md
+++ b/documentation/redisio_sentinel_instance.md
@@ -1,6 +1,6 @@
 # redisio_sentinel_instance
 
-Manages a single Redis Sentinel instance, including config, systemd unit, and service state.
+Manages a single Redis or Valkey Sentinel instance, including config, systemd unit, and service state.
 
 ## Actions
 
@@ -11,6 +11,7 @@ Manages a single Redis Sentinel instance, including config, systemd unit, and se
 
 - `instance_name` (`String`, default: name): Sentinel instance identifier
 - `package_install` (`Boolean`, default: `false`): Whether package install conventions should be used for binaries
+- `server_implementation` (`String`, default: `redis`): Select `redis` or `valkey`
 - `install_dir` (`String`, default: `nil`): Alternate source install prefix
 - `bin_path` (`String`, default: derived): Binary directory override
 - `sentinel_bind` (`String`, default: `nil`): Optional bind address
@@ -31,6 +32,22 @@ Manages a single Redis Sentinel instance, including config, systemd unit, and se
 ```ruby
 redisio_sentinel_instance 'mycluster' do
   package_install true
+  masters [
+    {
+      master_name: 'mycluster_master',
+      master_ip: '127.0.0.1',
+      master_port: 6379,
+    },
+  ]
+end
+```
+
+### Create a Valkey sentinel
+
+```ruby
+redisio_sentinel_instance 'mycluster' do
+  package_install true
+  server_implementation 'valkey'
   masters [
     {
       master_name: 'mycluster_master',

--- a/documentation/redisio_server.md
+++ b/documentation/redisio_server.md
@@ -1,6 +1,6 @@
 # redisio_server
 
-Manages a single Redis server instance, including config, systemd unit, runtime directories, and service state.
+Manages a single Redis or Valkey server instance, including config, systemd unit, runtime directories, and service state.
 
 ## Actions
 
@@ -11,14 +11,15 @@ Manages a single Redis server instance, including config, systemd unit, runtime 
 
 - `instance_name` (`String`, default: name): Instance identifier used in service/config naming
 - `package_install` (`Boolean`, default: `false`): Whether package install conventions should be used for binaries
+- `server_implementation` (`String`, default: `redis`): Select `redis` or `valkey`
 - `install_dir` (`String`, default: `nil`): Alternate source install prefix
 - `bin_path` (`String`, default: derived): Binary directory override
 - `port` (`String`, `Integer`, default: `6379`): Listening port
 - `name_override` (`String`, default: `nil`): Alternate config/service name when needed for compatibility
-- `configdir` (`String`, default: `/etc/redis`): Config directory
-- `datadir` (`String`, default: `/var/lib/redis`): Data directory
-- `user` (`String`, default: `redis`): Service user
-- `group` (`String`, default: `redis`): Service group
+- `configdir` (`String`, default: implementation specific): Config directory
+- `datadir` (`String`, default: implementation specific): Data directory
+- `user` (`String`, default: implementation specific): Service user
+- `group` (`String`, default: implementation specific): Service group
 - `permissions` (`String`, default: `0644`): Mode for the rendered config file
 - `save` (`Array`, `String`, default: `nil`): Save directives for the instance
 - `logfile` (`String`, default: `nil`): Optional log file path
@@ -36,6 +37,15 @@ Manages a single Redis server instance, including config, systemd unit, runtime 
 ```ruby
 redisio_server '6379' do
   package_install true
+end
+```
+
+### Create a Valkey instance
+
+```ruby
+redisio_server '6379' do
+  package_install true
+  server_implementation 'valkey'
 end
 ```
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,14 +4,44 @@ require 'shellwords'
 
 module RedisioCookbook
   module Helpers
-    def platform_package_name
-      return 'redis6' if platform_family?('amazon')
-      return 'redis-server' if platform_family?('debian')
-
-      'redis'
+    def valkey_implementation?(server_implementation)
+      server_implementation.to_s == 'valkey'
     end
 
-    def platform_default_home
+    def package_only_implementation?(server_implementation)
+      valkey_implementation?(server_implementation)
+    end
+
+    def validate_server_implementation!(package_install:, server_implementation:)
+      return unless package_only_implementation?(server_implementation) && !package_install
+
+      raise 'Valkey support currently requires package_install true'
+    end
+
+    def platform_package_names(server_implementation:, include_sentinel: false)
+      if valkey_implementation?(server_implementation)
+        if platform_family?('debian')
+          packages = %w(valkey-server valkey-tools)
+          packages << 'valkey-sentinel' if include_sentinel
+          return packages
+        end
+
+        return ['valkey']
+      end
+
+      return ['redis6'] if platform_family?('amazon')
+      return ['redis-server'] if platform_family?('debian')
+
+      ['redis']
+    end
+
+    def platform_package_name(server_implementation:)
+      platform_package_names(server_implementation: server_implementation).first
+    end
+
+    def platform_default_home(server_implementation:)
+      return '/var/lib/valkey' if valkey_implementation?(server_implementation)
+
       '/var/lib/redis'
     end
 
@@ -21,19 +51,32 @@ module RedisioCookbook
       '/bin/sh'
     end
 
-    def platform_default_group
+    def platform_default_group(server_implementation:)
+      return 'valkey' if valkey_implementation?(server_implementation)
+
       'redis'
     end
 
-    def platform_default_config_dir
+    def platform_default_config_dir(server_implementation:)
+      return '/etc/valkey' if valkey_implementation?(server_implementation)
+
       '/etc/redis'
     end
 
-    def platform_default_service_name
+    def platform_default_service_name(server_implementation:)
+      return 'valkey' if valkey_implementation?(server_implementation)
       return 'redis6' if platform_family?('amazon')
       return 'redis-server' if platform_family?('debian')
 
       'redis'
+    end
+
+    def package_default_service_names(server_implementation:)
+      if valkey_implementation?(server_implementation)
+        return %w(valkey valkey-sentinel)
+      end
+
+      [platform_default_service_name(server_implementation: server_implementation)]
     end
 
     def platform_default_bin_path(package_install:, install_dir:)
@@ -43,17 +86,27 @@ module RedisioCookbook
       '/usr/local/bin'
     end
 
+    def platform_default_base_piddir(server_implementation:)
+      return '/var/run/valkey' if valkey_implementation?(server_implementation)
+
+      '/var/run/redis'
+    end
+
     def source_build_packages
       return %w(tar gcc g++ make libc6-dev libssl-dev) if platform_family?('debian')
 
       %w(tar gcc gcc-c++ make glibc-devel openssl-devel)
     end
 
-    def redis_service_name(instance_name)
+    def redis_service_name(instance_name, server_implementation:)
+      return "valkey@#{instance_name}" if valkey_implementation?(server_implementation)
+
       "redis@#{instance_name}"
     end
 
-    def sentinel_service_name(instance_name)
+    def sentinel_service_name(instance_name, server_implementation:)
+      return "valkey-sentinel@#{instance_name}" if valkey_implementation?(server_implementation)
+
       "redis-sentinel@#{instance_name}"
     end
 
@@ -74,38 +127,61 @@ module RedisioCookbook
       }
     end
 
-    def redis_server_binary_name(package_install:, package_name:)
+    def redis_server_binary_name(package_install:, package_name:, server_implementation:)
+      return 'valkey-server' if valkey_implementation?(server_implementation)
       return 'redis6-server' if package_install && package_name == 'redis6'
 
       'redis-server'
     end
 
-    def redis_cli_binary_name(package_install:, package_name:)
+    def redis_cli_binary_name(package_install:, package_name:, server_implementation:)
+      return 'valkey-cli' if valkey_implementation?(server_implementation)
       return 'redis6-cli' if package_install && package_name == 'redis6'
 
       'redis-cli'
     end
 
-    def redis_server_binary(bin_path, options = nil, package_install: nil, package_name: nil)
+    def redis_server_binary(bin_path, options = nil, package_install: nil, package_name: nil, server_implementation: nil)
       if options.is_a?(Hash)
         package_install = options.fetch(:package_install, package_install)
         package_name = options.fetch(:package_name, package_name)
+        server_implementation = options.fetch(:server_implementation, server_implementation)
       end
 
-      ::File.join(bin_path, redis_server_binary_name(package_install: package_install, package_name: package_name))
+      ::File.join(
+        bin_path,
+        redis_server_binary_name(
+          package_install: package_install,
+          package_name: package_name,
+          server_implementation: server_implementation
+        )
+      )
     end
 
-    def redis_cli_binary(bin_path, options = nil, package_install: nil, package_name: nil)
+    def redis_cli_binary(bin_path, options = nil, package_install: nil, package_name: nil, server_implementation: nil)
       if options.is_a?(Hash)
         package_install = options.fetch(:package_install, package_install)
         package_name = options.fetch(:package_name, package_name)
+        server_implementation = options.fetch(:server_implementation, server_implementation)
       end
 
-      ::File.join(bin_path, redis_cli_binary_name(package_install: package_install, package_name: package_name))
+      ::File.join(
+        bin_path,
+        redis_cli_binary_name(
+          package_install: package_install,
+          package_name: package_name,
+          server_implementation: server_implementation
+        )
+      )
     end
 
-    def installed_redis_version(bin_path, package_install:, package_name:)
-      redis_server = redis_server_binary(bin_path, package_install: package_install, package_name: package_name)
+    def installed_redis_version(bin_path, package_install:, package_name:, server_implementation:)
+      redis_server = redis_server_binary(
+        bin_path,
+        package_install: package_install,
+        package_name: package_name,
+        server_implementation: server_implementation
+      )
       return unless ::File.exist?(redis_server)
 
       command = shell_out!("#{Shellwords.escape(redis_server)} -v", timeout: 30)

--- a/resources/_partial/_base.rb
+++ b/resources/_partial/_base.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 property :version
-property :base_piddir, String, default: '/var/run/redis'
-property :user, String, default: 'redis'
-property :group, String, default: 'redis'
+property :server_implementation, String, equal_to: %w(redis valkey), default: 'redis'
+property :base_piddir, String, default: lazy { server_implementation == 'valkey' ? '/var/run/valkey' : '/var/run/redis' }
+property :user, String, default: lazy { server_implementation == 'valkey' ? 'valkey' : 'redis' }
+property :group, String, default: lazy { server_implementation == 'valkey' ? 'valkey' : 'redis' }
 property :uid
 property :systemuser, [true, false], default: true
 property :homedir

--- a/resources/_partial/_server.rb
+++ b/resources/_partial/_server.rb
@@ -7,7 +7,7 @@ property :tcpbacklog, String, default: '511'
 property :address, default: nil
 property :databases, String, default: '16'
 property :backuptype, String, default: 'rdb'
-property :datadir, String, default: '/var/lib/redis'
+property :datadir, String, default: lazy { server_implementation == 'valkey' ? '/var/lib/valkey' : '/var/lib/redis' }
 property :unixsocket, default: nil
 property :unixsocketperm, default: nil
 property :timeout, String, default: '0'

--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -4,9 +4,10 @@ provides :redisio_configure
 unified_mode true
 
 property :version, [String, NilClass]
-property :base_piddir, String, default: '/var/run/redis'
-property :user, String, default: 'redis'
-property :group, String, default: 'redis'
+property :server_implementation, String, equal_to: %w(redis valkey), default: 'redis'
+property :base_piddir, String, default: lazy { server_implementation == 'valkey' ? '/var/run/valkey' : '/var/run/redis' }
+property :user, String, default: lazy { server_implementation == 'valkey' ? 'valkey' : 'redis' }
+property :group, String, default: lazy { server_implementation == 'valkey' ? 'valkey' : 'redis' }
 property :default_settings, Hash, default: {}
 property :servers, [Array, NilClass], default: nil
 property :package_install, [true, false], default: false
@@ -35,6 +36,7 @@ action :create do
 
     redisio_server instance_name do
       version new_resource.version || merged['version']
+      server_implementation new_resource.server_implementation
       base_piddir new_resource.base_piddir
       user merged.fetch('user', new_resource.user)
       group merged.fetch('group', new_resource.group)

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -6,6 +6,7 @@ unified_mode true
 property :package_install, [true, false], default: false
 property :package_name, [String, NilClass]
 property :version, [String, NilClass]
+property :server_implementation, String, equal_to: %w(redis valkey), default: 'redis'
 property :download_url, [String, NilClass]
 property :download_dir, String, default: lazy { Chef::Config[:file_cache_path] }
 property :artifact_type, String, default: 'tar.gz'
@@ -16,8 +17,14 @@ property :install_dir, [String, NilClass]
 action_class do
   include RedisioCookbook::Helpers
 
+  def resolved_package_names
+    return Array(new_resource.package_name) if new_resource.package_name
+
+    platform_package_names(server_implementation: new_resource.server_implementation, include_sentinel: true)
+  end
+
   def resolved_package_name
-    new_resource.package_name || platform_package_name
+    resolved_package_names.first
   end
 
   def resolved_version
@@ -40,7 +47,12 @@ action_class do
   end
 
   def resolved_server_binary
-    redis_server_binary(resolved_bin_path, package_install: new_resource.package_install, package_name: resolved_package_name)
+    redis_server_binary(
+      resolved_bin_path,
+      package_install: new_resource.package_install,
+      package_name: resolved_package_name,
+      server_implementation: new_resource.server_implementation
+    )
   end
 
   def tarball_name
@@ -56,29 +68,47 @@ action_class do
   end
 
   def package_service_name
-    platform_default_service_name
+    platform_default_service_name(server_implementation: new_resource.server_implementation)
+  end
+
+  def package_service_names
+    package_default_service_names(server_implementation: new_resource.server_implementation)
   end
 end
 
 action :create do
+  validate_server_implementation!(
+    package_install: new_resource.package_install,
+    server_implementation: new_resource.server_implementation
+  )
+
   if new_resource.package_install
     if platform_family?('debian')
       apt_update 'redisio-package-cache'
     end
 
-    package resolved_package_name do
-      version resolved_version unless resolved_version.nil?
+    resolved_package_names.each do |package_name|
+      package package_name do
+        version resolved_version unless resolved_version.nil?
+      end
     end
 
-    service package_service_name do
-      action %i(stop disable)
+    package_service_names.each do |service_name|
+      service service_name do
+        action %i(stop disable)
+      end
     end
   else
     source_build_packages.each do |build_package|
       package build_package
     end
 
-    current_version = installed_redis_version(resolved_bin_path, package_install: new_resource.package_install, package_name: resolved_package_name)
+    current_version = installed_redis_version(
+      resolved_bin_path,
+      package_install: new_resource.package_install,
+      package_name: resolved_package_name,
+      server_implementation: new_resource.server_implementation
+    )
     converge_if_changed :version do
       if current_version == resolved_version || (current_version && new_resource.safe_install)
         Chef::Log.info("Skipping Redis source install because #{current_version} is already present")
@@ -112,18 +142,44 @@ action :create do
 end
 
 action :delete do
+  validate_server_implementation!(
+    package_install: new_resource.package_install,
+    server_implementation: new_resource.server_implementation
+  )
+
   if new_resource.package_install
-    service package_service_name do
-      action %i(stop disable)
+    package_service_names.each do |service_name|
+      service service_name do
+        action %i(stop disable)
+      end
     end
 
-    package resolved_package_name do
-      action :remove
+    resolved_package_names.each do |package_name|
+      package package_name do
+        action :remove
+      end
     end
   else
-    binaries = %w(redis-benchmark redis-check-aof redis-check-rdb redis-sentinel)
-    binaries.unshift(redis_server_binary_name(package_install: new_resource.package_install, package_name: resolved_package_name))
-    binaries.unshift(redis_cli_binary_name(package_install: new_resource.package_install, package_name: resolved_package_name))
+    binaries = if new_resource.server_implementation == 'valkey'
+                 %w(valkey-benchmark valkey-check-aof valkey-check-rdb valkey-sentinel valkey-server valkey-cli)
+               else
+                 binaries = %w(redis-benchmark redis-check-aof redis-check-rdb redis-sentinel)
+                 binaries.unshift(
+                   redis_server_binary_name(
+                     package_install: new_resource.package_install,
+                     package_name: resolved_package_name,
+                     server_implementation: new_resource.server_implementation
+                   )
+                 )
+                 binaries.unshift(
+                   redis_cli_binary_name(
+                     package_install: new_resource.package_install,
+                     package_name: resolved_package_name,
+                     server_implementation: new_resource.server_implementation
+                   )
+                 )
+                 binaries
+               end
 
     binaries.each do |binary|
       file ::File.join(resolved_bin_path, binary) do

--- a/resources/sentinel.rb
+++ b/resources/sentinel.rb
@@ -4,9 +4,10 @@ provides :redisio_sentinel
 unified_mode true
 
 property :version, [String, NilClass]
-property :base_piddir, String, default: '/var/run/redis'
-property :user, String, default: 'redis'
-property :group, String, default: 'redis'
+property :server_implementation, String, equal_to: %w(redis valkey), default: 'redis'
+property :base_piddir, String, default: lazy { server_implementation == 'valkey' ? '/var/run/valkey' : '/var/run/redis' }
+property :user, String, default: lazy { server_implementation == 'valkey' ? 'valkey' : 'redis' }
+property :group, String, default: lazy { server_implementation == 'valkey' ? 'valkey' : 'redis' }
 property :sentinel_defaults, Hash, default: {}
 property :sentinels, [Array, NilClass], default: nil
 property :package_install, [true, false], default: false
@@ -88,6 +89,7 @@ action :create do
 
     redisio_sentinel_instance instance_name do
       version new_resource.version || merged['version']
+      server_implementation new_resource.server_implementation
       base_piddir new_resource.base_piddir
       user merged.fetch('user', new_resource.user)
       group merged.fetch('group', new_resource.group)

--- a/resources/sentinel_instance.rb
+++ b/resources/sentinel_instance.rb
@@ -26,16 +26,20 @@ property :client_reconfig_script, String
 action_class do
   include RedisioCookbook::Helpers
 
+  def resolved_user
+    new_resource.user
+  end
+
   def resolved_instance_name
     (new_resource.name_override || new_resource.instance_name).to_s
   end
 
   def resolved_group
-    new_resource.group || platform_default_group
+    new_resource.group || platform_default_group(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_homedir
-    new_resource.homedir || platform_default_home
+    new_resource.homedir || platform_default_home(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_shell
@@ -43,7 +47,7 @@ action_class do
   end
 
   def resolved_configdir
-    new_resource.configdir || platform_default_config_dir
+    new_resource.configdir || platform_default_config_dir(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_bin_path
@@ -51,7 +55,7 @@ action_class do
   end
 
   def resolved_package_name
-    new_resource.package_name || platform_package_name
+    new_resource.package_name || platform_package_name(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_version_hash
@@ -60,7 +64,12 @@ action_class do
               elsif new_resource.package_install
                 '7.0.0'
               else
-                installed_redis_version(resolved_bin_path, package_install: new_resource.package_install, package_name: resolved_package_name)
+                installed_redis_version(
+                  resolved_bin_path,
+                  package_install: new_resource.package_install,
+                  package_name: resolved_package_name,
+                  server_implementation: new_resource.server_implementation
+                )
               end
 
     redis_version_to_hash(version || '0.0.0')
@@ -137,11 +146,20 @@ action_class do
   end
 
   def service_name
-    sentinel_service_name(resolved_instance_name)
+    sentinel_service_name(resolved_instance_name, server_implementation: new_resource.server_implementation)
+  end
+
+  def implementation_name
+    new_resource.server_implementation == 'valkey' ? 'Valkey Sentinel' : 'Redis Sentinel'
   end
 end
 
 action :create do
+  validate_server_implementation!(
+    package_install: new_resource.package_install,
+    server_implementation: new_resource.server_implementation
+  )
+
   user new_resource.user do
     comment 'Redis service account'
     manage_home true
@@ -159,7 +177,7 @@ action :create do
   end
 
   directory resolved_piddir do
-    owner new_resource.user
+    owner resolved_user
     group resolved_group
     mode '0755'
     recursive true
@@ -167,7 +185,7 @@ action :create do
 
   unless resolved_log_directory.nil?
     directory resolved_log_directory do
-      owner new_resource.user
+      owner resolved_user
       group resolved_group
       mode '0755'
       recursive true
@@ -176,7 +194,7 @@ action :create do
 
   unless resolved_log_file.nil?
     file resolved_log_file do
-      owner new_resource.user
+      owner resolved_user
       group resolved_group
       mode '0644'
       backup false
@@ -187,7 +205,7 @@ action :create do
   template config_path do
     source 'sentinel.conf.erb'
     cookbook 'redisio'
-    owner new_resource.user
+    owner resolved_user
     group resolved_group
     mode '0644'
     variables(
@@ -243,13 +261,18 @@ action :create do
   systemd_unit "#{service_name}.service" do
     content(
       Unit: {
-        Description: "Redis Sentinel (#{resolved_instance_name})",
+        Description: "#{implementation_name} (#{resolved_instance_name})",
         After: 'network.target',
       },
       Service: {
         Type: 'notify',
-        ExecStart: "#{redis_server_binary(resolved_bin_path, package_install: new_resource.package_install, package_name: resolved_package_name)} #{config_path} --sentinel --daemonize no",
-        User: new_resource.user,
+        ExecStart: "#{redis_server_binary(
+          resolved_bin_path,
+          package_install: new_resource.package_install,
+          package_name: resolved_package_name,
+          server_implementation: new_resource.server_implementation
+        )} #{config_path} --sentinel --daemonize no",
+        User: resolved_user,
         Group: resolved_group,
         LimitNOFILE: new_resource.maxclients + 32,
       },
@@ -267,6 +290,11 @@ action :create do
 end
 
 action :delete do
+  validate_server_implementation!(
+    package_install: new_resource.package_install,
+    server_implementation: new_resource.server_implementation
+  )
+
   service service_name do
     action %i(stop disable)
     supports status: true, restart: true

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -21,11 +21,11 @@ action_class do
   end
 
   def resolved_group
-    new_resource.group || platform_default_group
+    new_resource.group || platform_default_group(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_homedir
-    new_resource.homedir || platform_default_home
+    new_resource.homedir || platform_default_home(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_shell
@@ -33,7 +33,7 @@ action_class do
   end
 
   def resolved_configdir
-    new_resource.configdir || platform_default_config_dir
+    new_resource.configdir || platform_default_config_dir(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_bin_path
@@ -41,14 +41,19 @@ action_class do
   end
 
   def resolved_package_name
-    new_resource.package_name || platform_package_name
+    new_resource.package_name || platform_package_name(server_implementation: new_resource.server_implementation)
   end
 
   def resolved_version
     return new_resource.version if new_resource.version
     return '7.0.0' if new_resource.package_install
 
-    installed_redis_version(resolved_bin_path, package_install: new_resource.package_install, package_name: resolved_package_name)
+    installed_redis_version(
+      resolved_bin_path,
+      package_install: new_resource.package_install,
+      package_name: resolved_package_name,
+      server_implementation: new_resource.server_implementation
+    )
   end
 
   def resolved_version_hash
@@ -115,7 +120,8 @@ action_class do
   end
 
   def limits_file
-    "/etc/security/limits.d/redis-#{resolved_instance_name}.conf"
+    prefix = new_resource.server_implementation == 'valkey' ? 'valkey' : 'redis'
+    "/etc/security/limits.d/#{prefix}-#{resolved_instance_name}.conf"
   end
 
   def config_path
@@ -127,11 +133,20 @@ action_class do
   end
 
   def service_name
-    redis_service_name(resolved_instance_name)
+    redis_service_name(resolved_instance_name, server_implementation: new_resource.server_implementation)
+  end
+
+  def implementation_name
+    new_resource.server_implementation == 'valkey' ? 'Valkey' : 'Redis'
   end
 end
 
 action :create do
+  validate_server_implementation!(
+    package_install: new_resource.package_install,
+    server_implementation: new_resource.server_implementation
+  )
+
   secrets = resolved_data_bag_secret
 
   user resolved_user do
@@ -338,13 +353,18 @@ action :create do
   systemd_unit "#{service_name}.service" do
     content(
       Unit: {
-        Description: "Redis (#{resolved_instance_name}) persistent key-value database",
+        Description: "#{implementation_name} (#{resolved_instance_name}) persistent key-value database",
         Wants: 'network-online.target',
         After: 'network-online.target',
       },
       Service: {
         Type: 'notify',
-        ExecStart: "#{redis_server_binary(resolved_bin_path, package_install: new_resource.package_install, package_name: resolved_package_name)} #{config_path} --daemonize no",
+        ExecStart: "#{redis_server_binary(
+          resolved_bin_path,
+          package_install: new_resource.package_install,
+          package_name: resolved_package_name,
+          server_implementation: new_resource.server_implementation
+        )} #{config_path} --daemonize no",
         User: resolved_user,
         Group: resolved_group,
         LimitNOFILE: resolved_descriptors,
@@ -363,6 +383,11 @@ action :create do
 end
 
 action :delete do
+  validate_server_implementation!(
+    package_install: new_resource.package_install,
+    server_implementation: new_resource.server_implementation
+  )
+
   service service_name do
     action %i(stop disable)
     supports status: true, restart: true

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe RedisioCookbook::Helpers do
   let(:helper_class) do
     Class.new do
       include RedisioCookbook::Helpers
+
+      def platform_family?(*families)
+        families.include?('debian')
+      end
     end
   end
 
@@ -23,5 +27,16 @@ RSpec.describe RedisioCookbook::Helpers do
 
   it 'normalizes nested hashes to string keys' do
     expect(helper.deep_stringify_keys(foo: { bar: 1 })).to eq('foo' => { 'bar' => 1 })
+  end
+
+  it 'resolves valkey package names on debian' do
+    expect(helper.platform_package_names(server_implementation: 'valkey', include_sentinel: true)).to eq(
+      %w(valkey-server valkey-tools valkey-sentinel)
+    )
+  end
+
+  it 'builds valkey instance service names' do
+    expect(helper.redis_service_name('6379', server_implementation: 'valkey')).to eq('valkey@6379')
+    expect(helper.sentinel_service_name('cluster', server_implementation: 'valkey')).to eq('valkey-sentinel@cluster')
   end
 end

--- a/spec/unit/resources/redisio_configure_spec.rb
+++ b/spec/unit/resources/redisio_configure_spec.rb
@@ -49,4 +49,26 @@ describe 'redisio_configure' do
 
     it { is_expected.to create_template('/etc/redis/savetest.conf').with(mode: '0640') }
   end
+
+  context 'with valkey defaults' do
+    before do
+      version_output = 'Valkey server v=8.0.6 sha=00000000:1 malloc=jemalloc-5.3.0 bits=64 build=00000000'
+
+      stub_service_inactive('valkey@6379')
+      allow(File).to receive(:exist?).with('/usr/bin/valkey-server').and_return(true)
+      allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out!)
+        .with('/usr/bin/valkey-server -v')
+        .and_return(double(stdout: version_output))
+    end
+
+    recipe do
+      redisio_configure 'default' do
+        package_install true
+        server_implementation 'valkey'
+      end
+    end
+
+    it { is_expected.to create_template('/etc/valkey/6379.conf') }
+    it { is_expected.to enable_service('valkey@6379') }
+  end
 end

--- a/spec/unit/resources/redisio_install_spec.rb
+++ b/spec/unit/resources/redisio_install_spec.rb
@@ -19,6 +19,25 @@ describe 'redisio_install' do
     it { is_expected.to stop_service('redis-server') }
   end
 
+  context 'with valkey package install on ubuntu' do
+    platform 'ubuntu', '24.04'
+
+    recipe do
+      redisio_install 'default' do
+        package_install true
+        server_implementation 'valkey'
+      end
+    end
+
+    it { is_expected.to install_package('valkey-server') }
+    it { is_expected.to install_package('valkey-tools') }
+    it { is_expected.to install_package('valkey-sentinel') }
+    it { is_expected.to disable_service('valkey') }
+    it { is_expected.to stop_service('valkey') }
+    it { is_expected.to disable_service('valkey-sentinel') }
+    it { is_expected.to stop_service('valkey-sentinel') }
+  end
+
   context 'with package install on amazon linux 2023' do
     platform 'amazon', '2023'
 
@@ -30,6 +49,21 @@ describe 'redisio_install' do
 
     it { is_expected.to install_package('redis6') }
     it { is_expected.to disable_service('redis6') }
+  end
+
+  context 'with valkey package install on rocky linux 9' do
+    platform 'rocky', '9'
+
+    recipe do
+      redisio_install 'default' do
+        package_install true
+        server_implementation 'valkey'
+      end
+    end
+
+    it { is_expected.to install_package('valkey') }
+    it { is_expected.to disable_service('valkey') }
+    it { is_expected.to disable_service('valkey-sentinel') }
   end
 
   context 'with source install' do

--- a/spec/unit/resources/redisio_sentinel_instance_spec.rb
+++ b/spec/unit/resources/redisio_sentinel_instance_spec.rb
@@ -37,4 +37,35 @@ describe 'redisio_sentinel_instance' do
   it { is_expected.to create_systemd_unit('redis-sentinel@cluster.service') }
   it { is_expected.to enable_service('redis-sentinel@cluster') }
   it { is_expected.to start_service('redis-sentinel@cluster') }
+
+  context 'with a valkey package-backed sentinel' do
+    before do
+      version_output = 'Valkey server v=8.0.6 sha=00000000:1 malloc=jemalloc-5.3.0 bits=64 build=00000000'
+
+      stub_service_inactive('valkey-sentinel@cluster')
+      allow(File).to receive(:exist?).with('/usr/bin/valkey-server').and_return(true)
+      allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out!)
+        .with('/usr/bin/valkey-server -v')
+        .and_return(double(stdout: version_output))
+    end
+
+    recipe do
+      redisio_sentinel_instance 'cluster' do
+        package_install true
+        server_implementation 'valkey'
+        masters [
+          {
+            master_name: 'master6379',
+            master_ip: '127.0.0.1',
+            master_port: 6379,
+          },
+        ]
+      end
+    end
+
+    it { is_expected.to create_template('/etc/valkey/sentinel_cluster.conf') }
+    it { is_expected.to create_systemd_unit('valkey-sentinel@cluster.service') }
+    it { is_expected.to enable_service('valkey-sentinel@cluster') }
+    it { is_expected.to start_service('valkey-sentinel@cluster') }
+  end
 end

--- a/spec/unit/resources/redisio_sentinel_spec.rb
+++ b/spec/unit/resources/redisio_sentinel_spec.rb
@@ -36,4 +36,36 @@ describe 'redisio_sentinel' do
 
   it { is_expected.to create_template('/etc/redis/sentinel_cluster.conf') }
   it { is_expected.to render_file('/etc/redis/sentinel_cluster.conf').with_content(/sentinel monitor master6379 127.0.0.1 6379 2/) }
+
+  context 'with valkey defaults' do
+    before do
+      version_output = 'Valkey server v=8.0.6 sha=00000000:1 malloc=jemalloc-5.3.0 bits=64 build=00000000'
+
+      stub_service_inactive('valkey-sentinel@cluster')
+      allow(File).to receive(:exist?).with('/usr/bin/valkey-server').and_return(true)
+      allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out!)
+        .with('/usr/bin/valkey-server -v')
+        .and_return(double(stdout: version_output))
+    end
+
+    recipe do
+      redisio_sentinel 'default' do
+        package_install true
+        server_implementation 'valkey'
+        sentinels(
+          [
+            {
+              'name' => 'cluster',
+              'master_ip' => '127.0.0.1',
+              'master_port' => 6379,
+              'master_name' => 'master6379',
+            },
+          ]
+        )
+      end
+    end
+
+    it { is_expected.to create_template('/etc/valkey/sentinel_cluster.conf') }
+    it { is_expected.to render_file('/etc/valkey/sentinel_cluster.conf').with_content(/sentinel monitor master6379 127.0.0.1 6379 2/) }
+  end
 end

--- a/spec/unit/resources/redisio_server_spec.rb
+++ b/spec/unit/resources/redisio_server_spec.rb
@@ -50,4 +50,30 @@ describe 'redisio_server' do
     it { is_expected.to render_file('/etc/redis/savetest.conf').with_content(/save 60 10000/) }
     it { is_expected.to create_file('/var/log/redis/redis-16379.log') }
   end
+
+  context 'with a valkey package-backed instance' do
+    before do
+      version_output = 'Valkey server v=8.0.6 sha=00000000:1 malloc=jemalloc-5.3.0 bits=64 build=00000000'
+
+      stub_service_inactive('valkey@6379')
+      allow(File).to receive(:exist?).with('/usr/bin/valkey-server').and_return(true)
+      allow_any_instance_of(Chef::Mixin::ShellOut).to receive(:shell_out!)
+        .with('/usr/bin/valkey-server -v')
+        .and_return(double(stdout: version_output))
+    end
+
+    recipe do
+      redisio_server '6379' do
+        package_install true
+        server_implementation 'valkey'
+      end
+    end
+
+    it { is_expected.to create_directory('/etc/valkey') }
+    it { is_expected.to create_directory('/var/lib/valkey') }
+    it { is_expected.to create_template('/etc/valkey/6379.conf') }
+    it { is_expected.to create_systemd_unit('valkey@6379.service') }
+    it { is_expected.to enable_service('valkey@6379') }
+    it { is_expected.to start_service('valkey@6379') }
+  end
 end


### PR DESCRIPTION
## Summary
- add explicit `server_implementation` support for `redis` and `valkey` across install, server, sentinel, and wrapper resources
- switch Valkey package mode to Valkey-specific package names, binaries, users, paths, and generated systemd instance units
- document the new Valkey workflow and add ChefSpec coverage for the Valkey resolution paths

Closes #518
